### PR TITLE
Refactor codebase to use common C#/U# conventions  

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# VRChat Billiards
+# VRChat Billiards (New Networking Patch)
+
+This is the repository for improving the underlying netcode of VRCBilliards. It may be behind Xieve's main project, or ahead of it in others.
+
+This codebase is provided as-is, and is recommended for developers only.
+
+TODOS:
+
+1. Refactor VRCBilliards to have a more usable and maintable code style and structure.
+2. Address current stability concerns (as they arise)
+3. Port VRCBilliards to the new Udon Reliable Sync functionality (when it becomes available).
 
 ![](https://i.imgur.com/WsYGyHY.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VRChat Billiards (New Networking Patch)
 
-This is the repository for improving the underlying netcode of VRCBilliards. It may be behind Xieve's main project, or ahead of it in others.
+This is the repository for improving the underlying netcode of VRCBilliards. It may be behind Xieve's main project, or ahead of it, depending on the progress in the following TODOs.
 
 This codebase is provided as-is, and is recommended for developers only.
 

--- a/us/ht8b.cs
+++ b/us/ht8b.cs
@@ -665,10 +665,6 @@ public class ht8b : UdonSharpBehaviour
                     Vector3 p = cueVDir * vel;
                     ball_W[0] = Vector3.Cross(r, p) * -50.0f;
 
-#if HT8B_DEBUGGER
-                    _frp(FRP_WARN + "Angular velocity: " + ball_W[0].ToString() + ". Velocity: " + ball_V[0].ToString() + FRP_END);
-#endif
-
                     HitGenerically();
                 }
             }
@@ -807,20 +803,12 @@ public class ht8b : UdonSharpBehaviour
     {
         if (!string.Equals(newState, oldState))
         {
-#if HT8B_DEBUGGER
-            _frp(FRP_LOW + "OnDeserialization() :: netstr update" + FRP_END);
-#endif
-
             oldState = newState;
 
             // Check if local simulation is in progress, the event will fire off later when physics
             // are settled by the client
             if (gameIsSimulating)
             {
-#if HT8B_DEBUGGER
-                _frp(FRP_WARN + "local simulation is still running, the network update will occur after completion" + FRP_END);
-#endif
-
                 isUpdateLocked = true;
             }
             else
@@ -835,9 +823,6 @@ public class ht8b : UdonSharpBehaviour
     {
         if (!isGameOver)
         {
-#if HT8B_DEBUGGER
-            _frp(FRP_ERR + "Critical error: gameover was false when trying to _netpaclossy()" + FRP_END);
-#endif
             return;
         }
 
@@ -864,9 +849,6 @@ public class ht8b : UdonSharpBehaviour
     {
         if (localPlayerID < 0)
         {
-#if HT8B_DEBUGGER
-            _frp(FRP_ERR + "Critical error: local_playerid was less than 0 when trying to NetPack()" + FRP_END);
-#endif
             return;
         }
 
@@ -927,10 +909,6 @@ public class ht8b : UdonSharpBehaviour
         EncodeUint16(0x50, gameID);
 
         newState = Convert.ToBase64String(networkData, Base64FormattingOptions.None);
-
-#if HT8B_DEBUGGER
-        _frp(FRP_LOW + "NetPack()" + FRP_END);
-#endif
     }
 
     // Decode networking string
@@ -938,35 +916,18 @@ public class ht8b : UdonSharpBehaviour
     public void ReadNetworkData()
     {
         // CHECK ERROR ===================================================================================================
-#if HT8B_DEBUGGER
-        _frp(FRP_LOW + "incoming base64: " + netstr + FRP_END);
-#endif
 
         byte[] in_data = Convert.FromBase64String(newState);
         if (in_data.Length < 0x52)
         {
-
-#if HT8B_DEBUGGER
-            _frp(FRP_WARN + "Sync string too short for decode, skipping\n" + FRP_END);
-#endif
-
             return;
         }
 
         networkData = in_data;
-
-#if HT8B_DEBUGGER
-        _frp(FRP_LOW + _netstr_hex() + FRP_END);
-#endif
-
         // Throw out updates that are possible errournous
         ushort nextid = DecodeUint16(0x4E);
         if (nextid <= clock)
         {
-#if HT8B_DEBUGGER
-            _frp(FRP_WARN + "Packet ID was old ( " + nextid + " <= " + sn_packetid + " ). Throwing out update" + FRP_END);
-#endif
-
             return;
         }
         clock = nextid;
@@ -1013,10 +974,6 @@ public class ht8b : UdonSharpBehaviour
         if (gameID > oldGameID && !isGameOver)
         {
             // EV: 1
-#if HT8B_DEBUGGER
-            _frp(FRP_YES + " .EV: 1 (sn_gameid > sn_gameid_prv) -> NewGame" + FRP_END);
-#endif
-
             OnLocalNewGame();
         }
 
@@ -1024,10 +981,6 @@ public class ht8b : UdonSharpBehaviour
         if (turnID != oldTurnID)
         {
             // EV: 2
-#if HT8B_DEBUGGER
-            _frp(FRP_YES + " .EV: 2 (sn_turnid != sn_turnid_prv) -> NewTurn" + FRP_END);
-#endif
-
             OnLocalTurnChange();
         }
 
@@ -1035,10 +988,6 @@ public class ht8b : UdonSharpBehaviour
         if (oldOpen && !isOpen)
         {
             // EV: 3
-#if HT8B_DEBUGGER
-            _frp(FRP_YES + " .EV: 3 (sn_open_prv && !sn_open) -> DisplaySet" + FRP_END);
-#endif
-
             OnLocalTableClosed();
         }
 
@@ -1046,10 +995,6 @@ public class ht8b : UdonSharpBehaviour
         if (!oldGameOver && isGameOver)
         {
             // EV: 4
-#if HT8B_DEBUGGER
-            _frp(FRP_YES + " .EV: 4 (!sn_gameover_prv && sn_gamemover) -> Gameover" + FRP_END);
-#endif
-
             OnLocalGameOver();
             return;
         }
@@ -1096,10 +1041,6 @@ public class ht8b : UdonSharpBehaviour
             // Check if teammate placed the positioner
             if (!isFoul)
             {
-#if HT8B_DEBUGGER
-                _frp(FRP_YES + " .EV: 3 (!sn_foul && sn_foul_prv && sn_permit) -> Marker placed" + FRP_END);
-#endif
-
                 isReposition = false;
                 marker.SetActive(false);
             }
@@ -1306,10 +1247,6 @@ public class ht8b : UdonSharpBehaviour
         // Check if game in progress
         if (isGameOver)
         {
-#if HT8B_DEBUGGER
-            _frp(FRP_YES + "Starting new game" + FRP_END);
-#endif
-
             // Get gamestate rolling
             gameID++;
             isPlayerAllowedToPlay = true;
@@ -1344,13 +1281,6 @@ public class ht8b : UdonSharpBehaviour
                 }
             }
         }
-        else
-        {
-            // Should not be hit since v1.0.0
-#if HT8B_DEBUGGER
-            _frp(FRP_ERR + "game in progress" + FRP_END);
-#endif
-        }
     }
 
     // Completely reset ht8b state
@@ -1365,10 +1295,6 @@ public class ht8b : UdonSharpBehaviour
             Networking.LocalPlayer == Networking.GetOwner(playerTotems[1])
             || isGameOver)
         {
-#if HT8B_DEBUGGER
-            _frp(FRP_WARN + "Ending game early" + FRP_END);
-#endif
-
             isGameOver = true;
             isPlayerAllowedToPlay = false;
             gameIsSimulating = false;
@@ -1387,10 +1313,6 @@ public class ht8b : UdonSharpBehaviour
         else
         {
             // TODO: Make this a panel
-#if HT8B_DEBUGGER
-            _frp(FRP_ERR + "Reset is availible to: " + Networking.GetOwner(playerTotems[0]).displayName + " and " + Networking.GetOwner(playerTotems[1]).displayName + FRP_END);
-#endif
-
             resetMessage.text = "Only:\n" + Networking.GetOwner(playerTotems[0]).displayName + " and " + Networking.GetOwner(playerTotems[1]).displayName + "\ncan reset";
         }
     }
@@ -1406,10 +1328,6 @@ public class ht8b : UdonSharpBehaviour
         Networking.LocalPlayer.SetWalkSpeed(0.0f);
         Networking.LocalPlayer.SetRunSpeed(0.0f);
         Networking.LocalPlayer.SetStrafeSpeed(0.0f);
-
-#if HT8B_DEBUGGER
-        _frp(FRP_LOW + "Entering desktop overlay" + FRP_END);
-#endif
     }
 
     // Cue put down local
@@ -3018,10 +2936,6 @@ public class ht8b : UdonSharpBehaviour
                         // Error: Local believes that we are in lobby, but someone else is there
                         if (player.playerId != Networking.LocalPlayer.playerId)
                         {
-#if HT8B_DEBUGGER
-                            _frp(FRP_ERR + "Error: de-sync local lobby status" + FRP_END);
-#endif
-
                             localPlayerID = -1;
                             m_lobbyNames[i].text = "<color=\"#ff0000\">ERROR</color>";
                         }
@@ -3194,10 +3108,6 @@ public class ht8b : UdonSharpBehaviour
             {
                 if (id == 0)
                 {
-#if HT8B_DEBUGGER
-                    _frp(FRP_ERR + "( closing lobby )" + FRP_END);
-#endif
-
                     isLobbyClosed = true;
                     localPlayerID = -1;
 
@@ -3207,10 +3117,6 @@ public class ht8b : UdonSharpBehaviour
                 }
                 else
                 {
-#if HT8B_DEBUGGER
-                    _frp(FRP_YES + "Starting game!" + FRP_END);
-#endif
-
                     isRegionSelected = false;
                     StartNewGame();
                     return;
@@ -3220,21 +3126,11 @@ public class ht8b : UdonSharpBehaviour
             {
                 if ((int)localTeamID == id)
                 {
-#if HT8B_DEBUGGER
-                    _frp(FRP_WARN + "( leaving lobby )" + FRP_END);
-#endif
-
                     // Set owner back to host
                     Networking.SetOwner(Networking.GetOwner(m_playerslot_owners[0]), m_playerslot_owners[localPlayerID]);
 
                     // Mark locally out of game
                     localPlayerID = -1;
-                }
-                else
-                {
-#if HT8B_DEBUGGER
-                    _frp(FRP_LOW + "this button does nothing" + FRP_END);
-#endif
                 }
             }
 
@@ -3245,10 +3141,6 @@ public class ht8b : UdonSharpBehaviour
         // Create new lobby
         if (isLobbyClosed)
         {
-#if HT8B_DEBUGGER
-            _frp(FRP_YES + "Creating lobby" + FRP_END);
-#endif
-
             // Assign other players to us to signify not joined
             Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[1]);
             Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[2]);
@@ -3278,24 +3170,12 @@ public class ht8b : UdonSharpBehaviour
             {
                 JoinPlayer(3);
             }
-            else
-            {
-#if HT8B_DEBUGGER
-                _frp(FRP_ERR + "no slot availible" + FRP_END);
-#endif
-            }
         }
 
         // Team 2
         else if (isTeams && (Networking.GetOwner(m_playerslot_owners[2]).playerId == gameHost.playerId))
         {
             JoinPlayer(2);
-        }
-        else
-        {
-#if HT8B_DEBUGGER
-            _frp(FRP_ERR + "no slot availible" + FRP_END);
-#endif
         }
     }
 
@@ -3672,11 +3552,6 @@ public class ht8b : UdonSharpBehaviour
                         Vector3 r_1 = (raySphereOutput - ball_CO[0]) * BALL_1OR;
                         Vector3 p = desktopShootVector.normalized * vel;
                         ball_W[0] = Vector3.Cross(r_1, p) * -25.0f;
-
-#if HT8B_DEBUGGER
-                        _frp(FRP_WARN + "Angular velocity: " + ball_W[0].ToString() + ". Velocity: " + ball_V[0].ToString() + FRP_END);
-#endif
-
                         cue.transform.localPosition = new Vector3(2000.0f, 2000.0f, 2000.0f);
                         isTurnLocalLive = false;
                         HitGenerically();

--- a/us/ht8b.cs
+++ b/us/ht8b.cs
@@ -1,32 +1,5 @@
 ﻿/* 
- https://www.harrygodden.com
-
- live:	wrld_08badc69-7665-4dc5-8243-3867455dc17c
- dev:		wrld_9497c2da-97ee-4b2e-9f82-f9adb024b6fe
-
- Update log:
-	16.12.2020 (0.1.3a)	-	Fix for new game, wrong local turn colour
-								-	Fix for not losing match when scratch on pot 8 ball				( Thanks: Photographotter, Mystical )
-								-	Added permission info to console when fail reset
-	17.12.2020 (0.2.0a)	-	Predictive physics for cue ball
-								-  Fix for not winning when sink 8, and objective on same turn		( Thanks: Rosy )
-								-	Reduced code spaghet in decode routine
-								-	Improved algorithm for post-game state checking, should lend
-								   to easier implementation of optional rules.
-								-	Allow colour switching between UK/USA/Default colour sets
-								-  Grips change colour based on which turn it is
-					0.3.0a	-	Added desktop mode
-								-	Sink opponents ball = loss turn
-								-	Removed coloursets
-					0.3.1a	-	Desktop QOL
-					0.3.2a	-	Reduced sensitivity
-								-	Added pad bytes
-					0.3.7a	-	Quest support
-					0.3.8a	-	Switched network string to base64 encoded
-								-	Changed initial break setup
-					1.0.0		-	First full Release
-
- Networking Model Information:
+    Original Networking Model Information is below:
 	
 	This implementation of 8 ball is based around passing ownership between clients who are
 	playing the game. A player is 'registered' into the game when they have ownership of one
@@ -34,12 +7,12 @@
 
 	When a turn ends, the player who is currently playing will pack information into the 
 	networking string that the turn has been transferred, and once the remote client who is
-	associated with the opposite cue recieves the update, they will take ownership of the main
+	associated with the opposite cue receives the update, they will take ownership of the main
 	script.
 
 	The local player will have a 'permit' to shoot when it is their turn, which allows them
 	to interact with the physics world. As soon as the cue ball is shot, the script calculates
-	and compresses the necessery velocities and positions of the balls, and 1. sends that out
+	and compresses the necessary velocities and positions of the balls, and 1. sends that out
 	to remote clients, and 2. decodes it the same way themselves. So effectively all players
 	end up watching the exact same simulation at very close to the same time. In testing this
 	was immediate as it could be with a GB -> USA connection.
@@ -100,26 +73,25 @@
 	[ 0x50  ]	gameid					uint16
 
  Physics Implementation:
-	
 	Physics are done in 2D to save instructions. The implementation is designed to be
-	as numerically stable as possible (eg. using linear algebra as much as possible to
+	as numerically stable as possible (e.g. using linear algebra as much as possible to
 	be explicit about what and where stuff collides ).
 
 	Ball physic response is 100% pure elastic energy transfer, which even at one iteration
-	per physics update seems to give plausable enough results. balls can behave like a 
+	per physics update seems to give plausible enough results. balls can behave like a 
 	newtons cradle which is what we want.
 
 	Edge collisions are a little contrived and the reason why the table can ONLY be placed
-	at world orign. the table is divided into major and minor sections. some of the 
+	at world origin. the table is divided into major and minor sections. some of the 
 	calculations can be peeked at here: https://www.geogebra.org/m/jcteyvj6 . It is all
 	straight line equations.
 	
-	There MAY be deviations between SOME client cpus / platforms depending on the floating 
+	There MAY be deviations between SOME client CPUs / platforms depending on the floating 
 	point architecture, and who knows what the fuck C# will decide to do at runtime anyway. 
 	However after some testing this seems rare enough that we could not observe any
 	differences at all. If it does happen to be calculated differently, the remote clients
 	will catch up with the players game anyway. I reckon this is most likely going to
-	affect, if it does at all, only quest/pc crossplay and not much else.
+	affect, if it does at all, only quest/pc cross-play and not much else.
 
 	Physics are calculated on a fixed timestep, using accumulator model. If there is very
 	low framerate physics may run at a slower timescale if it passes the threshold where
@@ -128,22 +100,7 @@
 	The display balls have their position matched, and rotated based on pure rolling model.
 */
 
-// https://feedback.vrchat.com/feature-requests/p/udon-expose-shaderpropertytoid
-// #define USE_INT_UNIFORMS
-
-// Currently unstable..
-// #define HT8B_ALLOW_AUTOSWITCH
-
-#if !UNITY_ANDROID
-#define HT8B_DEBUGGER
-#else
-#define HT_QUEST
-#endif
-
-//#define COMPILE_FUNC_TESTS
-//#define MULTIGAMES_PORTAL
-//#define COMPILE_FUNC_TESTS
-#define MENU_DEV
+//#if !UNITY_ANDROID This is the correct flag to spot if something is on Quest or not
 
 using UdonSharp;
 using UnityEngine;
@@ -153,3152 +110,630 @@ using VRC.Udon;
 using System;
 using UnityEngine.Rendering;
 
-public class ht8b : UdonSharpBehaviour {
+/// <summary>
+/// Main Behaviour for the VRCBilliards 8Ball variant.
+/// </summary>
+public class ht8b : UdonSharpBehaviour
+{
 
-#region R_CONSTANTS
-
-#if HT_QUEST
-const float k_MAX_DELTA = 0.075f;						// Maximum steps/frame ( 5 ish )
+#if UNITY_ANDROID
+    const float MAX_DELTA = 0.075f;					// Maximum steps/frame ( 5 ish )
 #else
-const float k_MAX_DELTA = 0.1f;						// Maximum steps/frame ( 8 )
+    const float MAX_DELTA = 0.1f;                     // Maximum steps/frame ( 8 )
 #endif
 
-// Physics calculation constants (measurements are in meters)
+    // Physics calculation constants (measurements are in meters)
 
-const float k_FIXED_TIME_STEP = 0.0125f;					// time step in seconds per iteration
-const float k_FIXED_SUBSTEP	= 0.00125f;
-const float k_TIME_ALPHA		= 50.0f;						// (unused) physics interpolation
-const float k_TABLE_WIDTH		= 1.0668f;					// horizontal span of table
-const float k_TABLE_HEIGHT		= 0.6096f;					// vertical span of table
-const float k_BALL_DIAMETRE	= 0.06f;						// width of ball
-const float k_BALL_PL_X			= 0.03f;						// break placement X
-const float k_BALL_PL_Y			= 0.05196152422f;			// Break placement Y
-const float k_BALL_1OR			= 33.3333333333f;			// 1 over ball radius
-const float k_BALL_RSQR			= 0.0009f;					// ball radius squared
-const float k_BALL_DSQR			= 0.0036f;					// ball diameter squared
-const float k_BALL_DSQRPE		= 0.003598f;				// ball diameter squared plus epsilon
-const float k_POCKET_RADIUS	= 0.09f;						// Full diameter of pockets (exc ball radi)
-const float k_CUSHION_RSTT		= 0.79f;						// Coefficient of restituion against cushion
+    const float FIXED_TIME_STEP = 0.0125f;                    // time step in seconds per iteration
+    const float FIXED_SUBSTEP = 0.00125f;
+    const float TIME_ALPHA = 50.0f;                       // (unused) physics interpolation
+    const float TABLE_WIDTH = 1.0668f;                    // horizontal span of table
+    const float TABLE_HEIGHT = 0.6096f;                   // vertical span of table
+    const float BALL_DIAMETRE = 0.06f;                        // width of ball
+    const float BALL_PL_X = 0.03f;                        // break placement X
+    const float BALL_PL_Y = 0.05196152422f;           // Break placement Y
+    const float BALL_1OR = 33.3333333333f;            // 1 over ball radius
+    const float BALL_RSQR = 0.0009f;                  // ball radius squared
+    const float BALL_DSQR = 0.0036f;                  // ball diameter squared
+    const float BALL_DSQRPE = 0.003598f;              // ball diameter squared plus epsilon
+    const float POCKET_RADIUS = 0.09f;                        // Full diameter of pockets (exc ball radi)
+    const float CUSHION_RSTT = 0.79f;                     // Coefficient of restituion against cushion
+    const float ONE_OVER_ROOT_TWO = 0.70710678118f;            // 1 over root 2 (normalize +-1,+-1 vector)
+    const float ONE_OVER_ROOT_FIVE = 0.4472135955f;         // 1 over root 5 (normalize +-1,+-2 vector)
+    const float RANDOMIZE_F = 0.0001f;
+    const float POCKET_DEPTH = 0.04f;                     // How far back (roughly) do pockets absorb balls after this point
+    const float MIN_VELOCITY = 0.00005625f;               // SQUARED
+    const float FRICTION_EFF = 0.99f;                     // How much to multiply velocity by each update
+    const float F_SLIDE = 0.2f;                       // Friction coefficient of sliding
+    const float F_ROLL = 0.01f;                       // Friction coefficient of rolling
+    const float SPOT_POSITION_X = 0.5334f;                    // First X position of the racked balls
+    const float SPOT_CAROM_X = 0.8001f;                   // Spot position for carom mode
+    const float RACHEIGHT = -0.0702f;                   // Rack position on Y axis
+    const float GRAVITY = 9.80665f;                   // Earths gravitational acceleration
+    const float BALL_MASS = 0.16f;                        // Weight of ball in kg
+    const string FRP_LOW = "<color=\"#ADADAD\">";
+    const string FRP_ERR = "<color=\"#B84139\">";
+    const string FRP_WARN = "<color=\"#DEC521\">";
+    const string FRP_YES = "<color=\"#69D128\">";
+    const string FRP_END = "</color>";
+    Vector3 CONTACT_POINT = new Vector3(0.0f, -0.03f, 0.0f); // Vectors cannot be const.
 
-const float k_1OR2				= 0.70710678118f;			// 1 over root 2 (normalize +-1,+-1 vector)
-const float k_1OR5				= 0.4472135955f;			// 1 over root 5 (normalize +-1,+-2 vector)
-const float k_RANDOMIZE_F		= 0.0001f;
-
-const float k_POCKET_DEPTH		= 0.04f;						// How far back (roughly) do pockets absorb balls after this point
-const float k_MIN_VELOCITY		= 0.00005625f;				// SQUARED
-
-const float k_FRICTION_EFF		= 0.99f;						// How much to multiply velocity by each update
-
-const float k_F_SLIDE			= 0.2f;						// Friction coefficient of sliding
-const float k_F_ROLL				= 0.01f;						// Friction coefficient of rolling
-
-const float k_SPOT_POSITION_X = 0.5334f;					// First X position of the racked balls
-const float k_SPOT_CAROM_X		= 0.8001f;					// Spot position for carom mode
-
-const float k_RACK_HEIGHT		= -0.0702f;					// Rack position on Y axis
-const float k_GRAVITY			= 9.80665f;					// Earths gravitational acceleration
-const float k_BALL_MASS			= 0.16f;						// Weight of ball in kg
-
-public bool IS_ROLLING = false;
-
-Vector3 k_CONTACT_POINT = new Vector3( 0.0f, -0.03f, 0.0f );
-
-#if HT_QUEST
-uint ANDROID_UNIFORM_CLOCK = 0x00u;
-uint ANDROID_CLOCK_DIVIDER = 0x8u;
+#if UNITY_ANDROID
+    uint ANDROID_UNIFORM_CLOCK = 0x00u;
+    uint ANDROID_CLOCDIVIDER = 0x8u;
 #endif
 
-// Colour constants
-Color k_tableColourBlue		= new Color( 0.0f, 0.75f, 1.75f, 1.0f ); // Presets ..
-Color k_tableColourOrange	= new Color( 1.75f, 0.25f, 0.0f, 1.0f );
-Color k_tableColourRed		= new Color( 1.2f, 0.0f, 0.0f, 1.0f );
-Color k_tableColorWhite		= new Color( 1.0f, 1.0f, 1.0f, 1.0f );
-Color k_tableColourBlack	= new Color( 0.01f, 0.01f, 0.01f, 1.0f );
-Color k_tableColourYellow	= new Color( 2.0f, 1.0f, 0.0f, 1.0f );
-Color k_tableColourPink		= new Color( 2.0f, 0.0f, 1.5f, 1.0f );
-Color k_tableColourGreen	= new Color( 0.0f, 2.0f, 0.0f, 1.0f );
-Color k_tableColourLBlue	= new Color( 0.3f, 0.6f, 1.0f, 1.0f );
-
-Color k_markerColourOK		= new Color( 0.0f, 1.0f, 0.0f, 1.0f );
-Color k_markerColourNO		= new Color( 1.0f, 0.0f, 0.0f, 1.0f );
-
-Color k_gripColourActive	= new Color( 0.0f, 0.5f, 1.1f, 1.0f );
-Color k_gripColourInactive = new Color( 0.34f, 0.34f, 0.34f, 1.0f );
-
-Color k_fabricColour_gray	= new Color( 0.3f, 0.3f, 0.3f, 1.0f );
-Color k_fabricColour_red	= new Color( 0.9f, 0.2f, 0.1f, 1.0f );
-Color k_fabricColour_blue	= new Color( 0.1f, 0.6f, 1.0f, 1.0f );
-Color k_fabricColour_white = new Color( 0.8f, 0.8f, 0.8f, 1.0f );
-Color k_fabricColour_green = new Color( 0.15f, 0.75f, 0.3f, 1.0f );
-
-Color k_aimColour_aim		= new Color( 0.7f, 0.7f, 0.7f, 1.0f );
-Color k_aimColour_locked	= new Color( 1.0f, 1.0f, 1.0f, 1.0f );
-
-const string FRP_LOW =	"<color=\"#ADADAD\">";
-const string FRP_ERR =	"<color=\"#B84139\">";
-const string FRP_WARN = "<color=\"#DEC521\">";
-const string FRP_YES =	"<color=\"#69D128\">";
-const string FRP_END =	"</color>";
-
-#endregion
-
-#region R_INSPECTOR
-
-// Other behaviours
-//[SerializeField]			ht8b_menu		menuController;
-[SerializeField]			ht8b_cue[]		gripControllers;
-
-// GameObjects
-[SerializeField] public GameObject[]	balls_render;
-[SerializeField] public GameObject		cuetip;
-[SerializeField]			GameObject		guideline;
-[SerializeField]			GameObject		guidefspin;
-[SerializeField]			GameObject		devhit;
-[SerializeField]			GameObject[]	playerTotems;
-[SerializeField]			GameObject[]	cueTips;
-[SerializeField]			GameObject		gametable;
-[SerializeField]			GameObject		infBaseTransform;
-[SerializeField]			GameObject		markerObj;
-[SerializeField]			GameObject		infHowToStart;
-[SerializeField]			GameObject		marker9ball;
-[SerializeField]			GameObject		tableoverlayUI;
-[SerializeField]			GameObject		fxColliderBase;
-[SerializeField]			GameObject		pocketblockers;
-[SerializeField]			GameObject		m_base;
-[SerializeField]			GameObject		point4ball;
-[SerializeField]			GameObject[]	cueRenderObjs;
-[SerializeField]			GameObject		select4b;
-
-// Meshes
-[SerializeField]			Mesh[]			cueball_meshes;
-[SerializeField]			Mesh				_9ball_mesh;
-[SerializeField]			Mesh				_4ball_mesh_add;
-[SerializeField]			Mesh				_4ball_mesh_minus;
-
-// Texts
-[SerializeField]			Text				ltext;
-[SerializeField]			Text[]			playerNames;
-[SerializeField]			Text				infText;
-[SerializeField]			Text				infReset;
-
-// Renderers
-[SerializeField] public	Renderer			scoreCardRenderer;
-
-// Materials
-[SerializeField]			Material			guidelineMat;
-[SerializeField] public Material			ballMaterial;
-[SerializeField]			Material[]		CueGripMaterials;
-[SerializeField] public Material			tableMaterial;
-[SerializeField]			Material			markerMaterial;
-
-[SerializeField] public Texture[]		textureSets;
-[SerializeField]			Texture			scorecard8ball;
-[SerializeField]			Texture			scorecard4ball;
-
-// Audio
-public GameObject AudioSourcePoolContainer;
-private AudioSource[] ball_AudioPool;
-public AudioSource CueTipAudio;
-[SerializeField]			AudioClip		snd_Intro;
-[SerializeField]			AudioClip		snd_Sink;
-[SerializeField]			AudioClip[]		snd_Hits;
-[SerializeField]			AudioClip		snd_NewTurn; 
-[SerializeField]			AudioClip		snd_PointMade;
-//[SerializeField]			AudioClip		snd_bad;
-[SerializeField]			AudioClip		snd_btn;
-[SerializeField]			AudioClip		snd_spin;
-[SerializeField]			AudioClip		snd_spinstop;
-[SerializeField]			AudioClip		snd_hitball;
+    const float SINA = 0.28078832987f;
+    const float SINA2 = 0.07884208619f;
+    const float COSA = 0.95976971915f;
+    const float COSA2 = 0.92115791379f;
+    const float EP1 = 1.79f;
+    const float A = 21.875f;
+    const float B = 6.25f;
+    const float F = 1.72909790282f;
+
+    // Shader uniforms
+    const string uniformTableColour = "_EmissionColour";
+    const string uniformScoreCardColour0 = "_Colour0";
+    const string uniformScoreCardColour1 = "_Colour1";
+    const string uniformScoreCardInfo = "_Info";
+    const string uniformMarkerColour = "_Color";
+    const string unofmrCueColour = "_EmissionColor";
+    const float desktopCursorSpeed = 0.035f;
+
+    const float I16_MAXf = 32767.0f;
+
+    const int FRP_MAX = 32;
+    int FRP_LEN = 0;
+    int FRP_PTR = 0;
+    string[] FRP_LINES = new string[32];
+
+    public bool isRolling = false;
+
+    [Header("Table Colours")]
+    public Color tableBlue = new Color(0.0f, 0.75f, 1.75f, 1.0f);
+    public Color tableOrange = new Color(1.75f, 0.25f, 0.0f, 1.0f);
+    public Color tableRed = new Color(1.2f, 0.0f, 0.0f, 1.0f);
+    public Color tableWhite = new Color(1.0f, 1.0f, 1.0f, 1.0f);
+    public Color tableBlack = new Color(0.01f, 0.01f, 0.01f, 1.0f);
+    public Color tableYellow = new Color(2.0f, 1.0f, 0.0f, 1.0f);
+    public Color tablePink = new Color(2.0f, 0.0f, 1.5f, 1.0f);
+    public Color tableGreen = new Color(0.0f, 2.0f, 0.0f, 1.0f);
+    public Color tableLightBlue = new Color(0.3f, 0.6f, 1.0f, 1.0f);
+    public Color markerOK = new Color(0.0f, 1.0f, 0.0f, 1.0f);
+    public Color markerNotOK = new Color(1.0f, 0.0f, 0.0f, 1.0f);
+    public Color gripColourActive = new Color(0.0f, 0.5f, 1.1f, 1.0f);
+    public Color gripColourInactive = new Color(0.34f, 0.34f, 0.34f, 1.0f);
+    public Color fabricGray = new Color(0.3f, 0.3f, 0.3f, 1.0f);
+    public Color fabricRed = new Color(0.9f, 0.2f, 0.1f, 1.0f);
+    public Color fabricBlue = new Color(0.1f, 0.6f, 1.0f, 1.0f);
+    public Color fabricWhite = new Color(0.8f, 0.8f, 0.8f, 1.0f);
+    public Color fabricGreen = new Color(0.15f, 0.75f, 0.3f, 1.0f);
+    public Color aimAiming = new Color(0.7f, 0.7f, 0.7f, 1.0f);
+    public Color aimLocked = new Color(1.0f, 1.0f, 1.0f, 1.0f);
+
+    [Header("Cues")]
+    public ht8b_cue[] gripControllers; // [FSP] [3/2/21] TODO: Rename all of these files/classes to actually be remotely sane
+
+    [Header("Table Objects")]
+    public GameObject[] ballsToRender;
+    public GameObject cueTip;
+    public GameObject guideline;
+    public GameObject devhit;
+    public GameObject[] playerTotems;
+    public GameObject[] cueTips;
+    public GameObject gameTable;
+    public GameObject infBaseTransform;
+    public GameObject marker;
+    public GameObject infHowToStart;
+    public GameObject marker9ball;
+    public GameObject tableOverlayUI;
+    public GameObject fxColliderBase;
+    public GameObject pocketBlockers;
+    public GameObject menuBase;
+    public GameObject point4Ball;
+    public GameObject[] cueRenderObjs;
+    public GameObject select4Ball;
+
+    // Meshes
+    private Mesh[] cueball_meshes;
+    private Mesh nineBall;
+    private Mesh fourBallAdd;
+    private Mesh fourBallMinus;
+
+    // Texts
+    private Text logText;
+    private Text[] playerNames;
+    private Text winMessage;
+    private Text resetMessage;
+
+    // Renderers
+    public Renderer scoreCardRenderer;
+
+    // Materials
+    public Material ballMaterial;
+    public Material tableMaterial;
+    public Texture[] sets;
+    public Material guidelineMat;
+    public Material[] cueGrips;
+    public Material markerMaterial;
+    public Texture scoreCard8Ball;
+    public Texture scoreCard4Ball;
+
+    // Audio
+    public GameObject audioSourcePoolContainer;
+    public AudioSource cueTipSrc;
+    public AudioClip introSfx;
+    public AudioClip sinkSfx;
+    public AudioClip[] hitsSfx;
+    public AudioClip newTurnSfx;
+    public AudioClip pointMadeSfx;
+    public AudioClip buttonSfx;
+    public AudioClip spinSfx;
+    public AudioClip spinStopSfx;
+    public AudioClip hitBallSfx;
+
+    private AudioSource[] ballPool;
 
-//Reflection Probes
-public ReflectionProbe Table_Probe;
+    //Reflection Probes
+    public ReflectionProbe tableReflection;
 
-#endregion
-
-// Audio Components
-AudioSource aud_main;
-
-#region R_GAMESTATE
-
-[UdonSynced]	private string netstr;		// dumpster fire
-					private string netstr_prv;
-					byte[]			net_data = new byte[0x52];
-
-// Networked gamestate
-//  data positions are marked as <#ushort>:<#bit> (<hexmask>) <description>
-
-uint	sn_pocketed		= 0x00U;		// 18:0 (0xffff)	Each bit represents each ball, if it has been pocketed or not
-public bool	sn_simulating	= false;		// 19:0 (0x01)		True whilst balls are rolling
-uint	sn_turnid		= 0x00U;		// 19:1 (0x02)		Whos turn is it, 0 or 1
-bool  sn_foul			= false;		// 19:2 (0x04)		End-of-turn foul marker
-bool  sn_open			= true;		// 19:3 (0x08)		Is the table open?
-uint  sn_playerxor	= 0x00;		// 19:4 (0x10)		What colour the players have chosen
-bool  sn_gameover		= true;		// 19:5 (0x20)		Game is complete
-uint  sn_winnerid		= 0x00U;		// 19:6 (0x40)		Who won the game if sn_gameover is set
-
-bool	sn_lobbyclosed	= true;
-
-[HideInInspector]
-public bool	sn_permit= false;		// 19:7 (0x80)		Permission for player to play
-
-// Modifiable -- ht8b_menu.cs
-
-[HideInInspector] 
-
-#if COMPILE_FUNC_TESTS
-public
-#endif
-
-									uint sn_gamemode	= 0;	// 19:8 (0x700)	Gamemode ID 3 bit	{ 0: 8 ball, 1: 9 ball, 2+: undefined }
-[HideInInspector] public	uint sn_timer		= 0;	// 19:13 (0x6000)	Timer ID 2 bit		{ 0: inf, 1: 10s, 2: 15s, 3: 30s, 4: 60s, 5: undefined }
-									bool sn_teams = false;	// 19:15 (0x8000)	Teams on/off (1 bit)
-
-ushort sn_packetid	= 0;			// 20:0 (0xffff)	Current packet number, used for locking updates so we dont accidently go back.
-											//							this behaviour was observed on some long connections so its necessary
-ushort sn_gameid		= 0;			// 21:0 (0xffff)	Game number
-ushort sn_gmspec		= 0;			// 22:0 (0xffff)	Game mode specific information
-
-// Cannot making a struct in C#, therefore values are duplicated
-
-// for gamestate deltas
-uint sn_pocketed_prv;
-uint sn_turnid_prv;
-bool sn_open_prv;
-bool sn_gameover_prv;
-ushort sn_gameid_prv;
-
-uint sn_gamemode_prv;
-uint sn_timer_prv;
-bool sn_teams_prv;
-bool sn_lobbyclosed_prv;
-
-// unused
-//bool sn_simulating_prv;
-//bool sn_foul_prv;
-//uint sn_playerxor_prv;
-//uint sn_colourset_prv;
-//bool sn_inmenu_prv;
-//uint sn_winnerid_prv;
-//bool sn_permit_prv;
-//bool sn_rs_call8_prv;
-//bool sn_rs_call_prv;
-//bool sn_rs_anyf_prv;
-
-// Local gamestates
-[HideInInspector]
-public bool	sn_armed	= false;		// Player is hitting
-bool	sn_updatelock	= false;		// We are waiting for our local simulation to finish, before we unpack data
-int	sn_firsthit		= 0;			// The first ball to be hit by cue ball
-
-int	sn_secondhit	= 0;
-int	sn_thirdhit		= 0;
-
-bool	sn_oursim		= false;		// If the simulation was initiated by us, only set from update
-
-byte	sn_wins0			= 0;			// Wins for player 0 (unused)
-byte	sn_wins1			= 0;			// Wins for player 1 (unused)
-
-float	introAminTimer = 0.0f;		// Ball dropper timer
-
-bool	ballsMoving		= false;		// Tracker variable to see if balls are still on the go
-
-bool	isReposition	= false;			// Repositioner is active
-float repoMaxX			= k_TABLE_WIDTH;	// For clamping to table or set lower for kitchen
-
-float timer_end		= 0.0f;		// What should the timer run out at
-float timer_recip		= 0.0f;		// 1 over time limit
-bool	timer_running	= false;
-
-bool	particle_alive = false;
-float	particle_time	= 0.0f;
-
-bool	fb_madepoint	= false;
-bool	fb_madefoul		= false;
-
-bool	fb_jp				= false;
-bool	fb_kr				= false;
-
-int[]	fb_scores = new int[2];
-
-bool	gm_is_0 = false;
-bool	gm_is_1 = false;
-bool	gm_is_2 = false;
-//bool	gm_is_3 = false;
-bool	gm_practice = false;			// Game should run in practice mode
-bool	region_selected = false;
-
-bool	dk_shootui = false;
-
-// Values that will get sucked in from the menu
-[HideInInspector] public int local_playerid = -1;
-								uint local_teamid = 0u;		// Interpreted value
-
-#endregion
-
-#region R_PHYS_MEM
-
-#if COMPILE_FUNC_TESTS
-public 
-#endif
-Vector3[] ball_CO = new Vector3[16];	// Current positions
-
-#if COMPILE_FUNC_TESTS
-public 
-#endif
-Vector3[] ball_V = new Vector3[16];	// Current velocities
-Vector3[] ball_W = new Vector3[16]; // Angular velocities
-
-#endregion
-
-// Shader uniforms
-//  *udon currently does not support integer uniform identifiers
-#if USE_INT_UNIFORMS
-
-int uniform_tablecolour;
-int uniform_scorecard_colour0;
-int uniform_scorecard_colour1;
-int uniform_scorecard_info;
-int uniform_marker_colour;
-int uniform_cue_colour;
-
-#else
-
-const string uniform_tablecolour = "_EmissionColour";
-const string uniform_scorecard_colour0 = "_Colour0";
-const string uniform_scorecard_colour1 = "_Colour1";
-const string uniform_scorecard_info = "_Info";
-const string uniform_marker_colour = "_Color";
-const string uniform_cue_colour = "_EmissionColor";
-
-#endif
-
-#region R_VFX
-
-Color tableSrcColour			= new Color( 1.0f, 1.0f, 1.0f, 1.0f );	// Runtime target colour
-Color tableCurrentColour	= new Color( 1.0f, 1.0f, 1.0f, 1.0f );	// Runtime actual colour
-
-// 'Pointer' colours.
-Color pColour0;		// Team 0
-Color pColour1;		// Team 1
-Color pColour2;		// No team / open / 9 ball
-Color pColourErr;
-Color pClothColour;
-
-// Updates table colour target to appropriate player colour
-void _vis_apply_tablecolour( uint idsrc )
-{
-	if( gm_is_2 )
-	{
-		if( sn_turnid == 0 )
-		{
-			cueRenderObjs[ 0 ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, pColour0 );
-			cueRenderObjs[ 1 ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, pColour1 * 0.5f );
-		}
-		else
-		{
-			cueRenderObjs[ 0 ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, pColour0 * 0.5f );
-			cueRenderObjs[ 1 ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, pColour1 );
-		}
-
-		tableSrcColour = k_tableColourBlack;
-	}
-	
-	else if( gm_is_1 )
-	{
-		cueRenderObjs[ sn_turnid ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, k_tableColorWhite );
-		cueRenderObjs[ sn_turnid ^ 0x1u ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, k_tableColourBlack );
-
-		tableSrcColour = pColour2;
-	}
-
-	else
-	{
-		if( !sn_open )
-		{
-			if( (idsrc ^ sn_playerxor) == 0 )
-			{
-				// Set table colour to blue
-				tableSrcColour = pColour0;
-			}
-			else
-			{
-				// Table colour to orange
-				tableSrcColour = pColour1;
-			}
-
-			cueRenderObjs[ sn_playerxor ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, pColour0 );
-			cueRenderObjs[ sn_playerxor ^ 0x1u ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, pColour1 );
-		}
-		else
-		{
-			tableSrcColour = pColour2;
-
-			cueRenderObjs[ sn_turnid ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, k_tableColorWhite );
-			cueRenderObjs[ sn_turnid ^ 0x1u ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, k_tableColourBlack );
-		}
-
-	}
-
-	CueGripMaterials[ sn_turnid ].SetColor( uniform_marker_colour, k_gripColourActive );
-	CueGripMaterials[ sn_turnid ^ 0x1u ].SetColor( uniform_marker_colour, k_gripColourInactive );
-}
-
-void _vis_showballs()
-{
-	if( gm_is_1 )
-	{
-		for( int i = 0; i <= 9; i ++ )
-			balls_render[ i ].SetActive( true );
-
-		for( int i = 10; i < 16; i ++ )
-			balls_render[ i ].SetActive( false );
-	}
-	else if( gm_is_2 )
-	{
-		for( int i = 1; i < 16; i ++ )
-			balls_render[ i ].SetActive( false );
-
-		balls_render[ 0 ].SetActive( true );
-		balls_render[ 2 ].SetActive( true );
-		balls_render[ 3 ].SetActive( true );
-		balls_render[ 9 ].SetActive( true );
-	}
-	else
-	{
-		for( int i = 0; i < 16; i ++ )
-		{
-			balls_render[ i ].SetActive( true );
-		}
-	}
-}
-
-public void _vis_updatecoloursources()
-{
-	if( gm_is_1 )	// 9 Ball / USA colours
-	{
-		pColour0 = k_tableColourLBlue;
-		pColour1 = k_tableColourLBlue;
-		pColour2 = k_tableColourLBlue;
-
-		pColourErr = k_tableColourBlack;	// No error effect
-		pClothColour = k_fabricColour_blue;
-
-		// 9 ball only uses one colourset / cloth colour
-		ballMaterial.SetTexture( "_MainTex", textureSets[ 3 ] );
-	}
-	else if( gm_is_2 )
-	{
-		pColour0 = k_tableColorWhite;
-		pColour1 = k_tableColourYellow;
-		
-		// Should not be used
-		pColour2 = k_tableColourRed;
-		pColourErr = k_tableColourRed;
-
-		ballMaterial.SetTexture( "_MainTex", textureSets[ 2 ] );
-		pClothColour = k_fabricColour_green;
-	}
-	else // Standard 8 ball derivatives
-	{
-		pColourErr = k_tableColourRed;
-		pColour2 = k_tableColorWhite;
-
-		pColour0 = k_tableColourBlue;
-		pColour1 = k_tableColourOrange;
-
-		ballMaterial.SetTexture( "_MainTex", textureSets[ 0 ] );
-		pClothColour = k_fabricColour_gray;
-	}
-	tableMaterial.SetColor( "_ClothColour", pClothColour );
-	Table_Probe.RenderProbe();
-}
-
-void _vis_disableobjects()
-{
-	guideline.SetActive( false );
-	devhit.SetActive( false );
-	infBaseTransform.SetActive( false );
-	markerObj.SetActive( false );
-	tableoverlayUI.SetActive( false );
-	marker9ball.SetActive( false );
-	point4ball.SetActive( false );
-	select4b.SetActive( false );
-}
-
-void _vis_spawn_floaty( Vector3 pos, Mesh m )
-{
-	point4ball.SetActive( true );
-	particle_alive = true;
-	particle_time = 0.1f;
-
-	// orient to be looking at player
-	Vector3 lpos = Networking.LocalPlayer.GetPosition();
-	Vector3 delta = lpos - this.transform.TransformPoint( pos );
-	float r = Mathf.Atan2( delta.x, delta.z );
-	point4ball.transform.localRotation = Quaternion.AngleAxis( r*Mathf.Rad2Deg, Vector3.up );
-
-	// set position
-	point4ball.transform.localPosition = pos;
-
-	// Set scale
-	point4ball.transform.localScale = Vector3.zero;
-
-	point4ball.GetComponent< MeshFilter >().sharedMesh = m;
-}
-
-void _vis_floaty_eval()
-{
-	float scale,s,v,e;
-
-	// Evaluate time
-	particle_time += Time.deltaTime * 0.25f;
-
-	// Sustained step
-	s = Mathf.Max( particle_time-0.1f, 0.0f );
-	v = Mathf.Min( particle_time*particle_time*100.0f, 21.0f*s*Mathf.Exp(-15.0f*s) );
-
-	// Exponential step
-	e = Mathf.Exp( -17.0f * Mathf.Pow( Mathf.Max( particle_time - 1.2f, 0.0f ), 3.0f ) );
-
-	scale = e*v*2.0f;
-
-	// Set scale
-	point4ball.transform.localScale = new Vector3( scale, scale, scale );
-
-	// Set position
-	Vector3 temp = point4ball.transform.localPosition;
-	temp.y = particle_time * 0.5f;
-	point4ball.transform.localPosition = temp;
-
-	// Particle death
-	if( particle_time > 2.0f )
-	{
-		particle_alive = false;
-		point4ball.SetActive( false );
-	}
-}
-
-#endregion
-
-void _timer_reset()
-{
-	if (sn_timer == 0)
-	{
-		timer_end = Time.timeSinceLevelLoad + 30.0f;
-		timer_recip = 0.03333333333f;
-	}
-	else
-	{
-		timer_end = Time.timeSinceLevelLoad + 60.0f;
-		timer_recip = 0.01666666666f;
-	}
-
-	timer_running = true;
-}
-
-#region R_LOCALEV
-
-void _onlocal_carompoint( Vector3 p )
-{
-	fb_madepoint = true;
-	aud_main.PlayOneShot( snd_PointMade, 1.0f );
-
-	fb_scores[ sn_turnid ] ++;
-
-	if( fb_scores[ sn_turnid ] > 10 )
-	{
-		fb_scores[ sn_turnid ] = 10;
-	}
-
-	_vis_spawn_floaty( p, _4ball_mesh_add );
-}
-
-void _onlocal_carompenalize( Vector3 p )
-{
-	fb_madefoul = true;
-	//aud_main.PlayOneShot( snd_bad, 1.0f );
-
-	fb_scores[ sn_turnid ] --;
-
-	if( fb_scores[ sn_turnid ] < 0 )
-	{
-		fb_scores[ sn_turnid ] = 0;
-	}
-
-	_vis_spawn_floaty( p, _4ball_mesh_minus );
-}
-
-// Called when a player first sinks a ball whilst the table was previously open
-void _onlocal_tableclosed()
-{
-	uint picker = sn_turnid ^ sn_playerxor;
-
-#if HT8B_DEBUGGER
-	_frp( FRP_YES + "(local) " + Networking.GetOwner( playerTotems[ sn_turnid ] ).displayName + ":" + sn_turnid + " is " + 
-		(picker == 0? "blues": "oranges") + FRP_END );
-#endif
-
-	_vis_apply_tablecolour( sn_turnid );
-	_onlocal_updatescorecard();
-
-	scoreCardRenderer.sharedMaterial.SetColor( uniform_scorecard_colour0, sn_playerxor == 0? pColour0: pColour1 );
-	scoreCardRenderer.sharedMaterial.SetColor( uniform_scorecard_colour1, sn_playerxor == 1? pColour0: pColour1 );
-}
-
-// End of the game. Both with/loss
-void _onlocal_gameover()
-{
-#if HT8B_DEBUGGER
-	_frp( FRP_YES + "(local) Winner of match: " + Networking.GetOwner( playerTotems[ sn_winnerid ] ).displayName + FRP_END );
-#endif
-
-	_vis_apply_tablecolour( sn_winnerid );
-
-	infText.text = Networking.GetOwner( playerTotems[ sn_winnerid ] ).displayName + " wins!";
-	infBaseTransform.SetActive( true );
-	marker9ball.SetActive( false );
-	tableoverlayUI.SetActive( false );
-
-#if !HT_QUEST
-	_vis_rackballs();	// To make sure rigidbodies are completely off
-#endif
-
-	isReposition = false;
-	markerObj.SetActive( false );
-
-	_onlocal_updatescorecard();
-
-	// Remove any access rights
-	local_playerid = -1;
-	_apply_cue_access();
-
-	_htmenu_enter();
-}
-
-void _onlocal_turnchange()
-{
-	// Effects
-	_vis_apply_tablecolour( sn_turnid );
-	aud_main.PlayOneShot( snd_NewTurn, 1.0f );
-
-	// Register correct cuetip
-	cuetip = cueTips[ sn_turnid ];
-
-	bool isOurTurn = ((local_playerid >= 0) && (local_teamid == sn_turnid)) || gm_practice;
-
-	if( gm_is_2 ) // 4 ball
-	{
-		// Swap cue ball and opponent cue
-		Vector3 temp = ball_CO[ 0 ];
-		ball_CO[ 0 ] = ball_CO[ 9 ];
-		ball_CO[ 9 ] = temp;
-
-		if( sn_turnid == 0 )
-		{
-			balls_render[ 0 ].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[ 0 ];
-			balls_render[ 9 ].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[ 1 ];
-		}
-		else
-		{
-			balls_render[ 9 ].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[ 0 ];
-			balls_render[ 0 ].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[ 1 ];
-		}
-	}
-	else
-	{
-		// White was pocketed
-		if( (sn_pocketed & 0x1u) == 0x1u )
-		{
-			ball_CO[0] = Vector3.zero;
-			ball_V[0] = Vector3.zero;
-			ball_W[0] = Vector3.zero;
-
-			sn_pocketed &= 0xFFFFFFFEu;
-		}
-	}
-
-	if( isOurTurn )
-	{
-		if( sn_foul )
-		{
-			isReposition = true;
-			repoMaxX = k_TABLE_WIDTH;
-			markerObj.SetActive( true );
-
-			markerObj.transform.localPosition = ball_CO[ 0 ];
-		}
-	}
-
-	// Force timer reset
-	if( sn_timer > 0 )
-	{
-		_timer_reset();
-	}
-}
-
-void _onlocal_updatescorecard()
-{
-	if( gm_is_2 )
-	{
-		scoreCardRenderer.sharedMaterial.SetVector( uniform_scorecard_info, new Vector4( fb_scores[ 0 ]*0.04681905f, fb_scores[ 1 ]*0.04681905f, 0.0f, 0.0f ) );
-	}
-	else
-	{
-		int[] counter0 = new int[2];
-
-		uint temp = sn_pocketed;
-
-		for( int j = 0; j < 2; j ++ )
-		{
-			for( int i = 0; i < 7; i ++ )
-			{
-				if( (temp & 0x4) > 0 )
-				{
-					counter0[ j ^ sn_playerxor ] ++;
-				}
-
-				temp >>= 1;
-			}
-		}
-
-		// Add black ball if we are winning the thing
-		if( sn_gameover )
-		{
-			counter0[ sn_winnerid ] += (int)((sn_pocketed & 0x2) >> 1);
-		}
-
-		scoreCardRenderer.sharedMaterial.SetVector( uniform_scorecard_info, new Vector4( counter0[0]*0.0625f, counter0[1]*0.0625f, 0.0f, 0.0f ) );
-	}
-}
-
-// Player scored an objective ball 
-void _onlocal_pocket_obj()
-{
-	// Make a bright flash
-	tableCurrentColour *= 1.9f;
-
-	aud_main.PlayOneShot( snd_Sink, 1.0f );
-}
-
-// Player scored a foul ball (cue, non-objective or 8 before set cleared)
-void _onlocal_pocket_enm()
-{
-	tableCurrentColour = pColourErr;
-
-	aud_main.PlayOneShot( snd_Sink, 1.0f );
-}
-
-// once balls stops rolling this is called
-void _onlocal_sim_end()
-{
-	sn_simulating = false;
-
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + "(local) SimEnd()" + FRP_END );
-	#endif
-
-	// Make sure we only run this from the client who initiated the move
-	if( sn_oursim )
-	{
-		sn_oursim = false;
-
-		// We are updating the game state so make sure we are network owner
-		Networking.SetOwner( Networking.LocalPlayer, this.gameObject );
-
-		// Owner state checks
-		#if HT8B_DEBUGGER
-		_frp( FRP_LOW + "Post-move state checking" + FRP_END );
-		#endif
-
-		uint bmask = 0xFFFCu;
-		uint emask = 0x0u;
-
-		// Quash down the mask if table has closed
-		if( !sn_open )
-		{
-			bmask = bmask & (0x1FCu << ((int)(sn_playerxor ^ sn_turnid) * 7));
-			emask = 0x1FCu << ((int)(sn_playerxor ^ sn_turnid ^ 0x1U) * 7);
-		}
-
-		// Common informations
-		bool isSetComplete = (sn_pocketed & bmask) == bmask;
-		bool isScratch = (sn_pocketed & 0x1U) == 0x1U;
-
-		// Append black to mask if set is done
-		if( isSetComplete )
-		{
-			bmask |= 0x2U;
-		}
-
-		// These are the resultant states we can set for each mode
-		// then the rest is taken care of
-		bool 
-			isObjectiveSink,
-			isOpponentSink,
-			winCondition,
-			foulCondition,
-			deferLossCondition
-		;
-
-		if( gm_is_0 )	// Standard 8 ball
-		{
-			isObjectiveSink = (sn_pocketed & bmask) > (sn_pocketed_prv & bmask);
-			isOpponentSink = (sn_pocketed & emask) > (sn_pocketed_prv & emask);
-
-			// Calculate if objective was not hit first
-			bool isWrongHit = ((0x1U << sn_firsthit) & bmask) == 0;
-
-			bool is8Sink = (sn_pocketed & 0x2U) == 0x2U;
-
-			winCondition = isSetComplete && is8Sink;
-			foulCondition = isScratch || isWrongHit;
-			
-			deferLossCondition = is8Sink;
-		} 
-		else if( gm_is_1 )	// 9 ball
-		{
-			// Rules are from: https://www.youtube.com/watch?v=U0SbHOXCtFw
-
-			// Rule #1: Cueball must strike the lowest number ball, first
-			bool isWrongHit = !(_lowest_ball( sn_pocketed_prv ) == sn_firsthit);
-
-			// Rule #2: Pocketing cueball, is a foul
-			
-			// Win condition: Pocket 9 ball ( at anytime )
-			winCondition = (sn_pocketed & 0x200u) == 0x200u;
-
-			// this video is hard to follow so im just gonna guess this is right
-			isObjectiveSink = (sn_pocketed & 0x3FEu) > (sn_pocketed_prv & 0x3FEu);
-			
-			isOpponentSink = false;
-			deferLossCondition = false;
-
-			foulCondition = isWrongHit || isScratch;
-
-			// TODO: Implement rail contact requirement
-		} 
-		else if( gm_is_2 ) // 4 ball
-		{
-			isObjectiveSink = fb_madepoint;
-			isOpponentSink = fb_madefoul;
-			foulCondition = false;
-			deferLossCondition = false;
-
-			winCondition = fb_scores[ sn_turnid ] >= 10;
-		}
-		else // Unkown mode
-		{
-			isObjectiveSink = true;
-			isOpponentSink = false;
-			winCondition = false;
-			foulCondition = false;
-			deferLossCondition = false;
-
-			if( (sn_pocketed & 0x1u) == 0x1u )
-			{
-				sn_foul = true;
-				_onlocal_turnchange();
-			}
-		}
-
-		if( winCondition )
-		{
-			if( foulCondition )
-			{
-				// Loss
-				_turn_win( sn_turnid ^ 0x1U );
-			}
-			else
-			{
-				// Win
-				_turn_win( sn_turnid );
-			}
-		}
-		else if( deferLossCondition )
-		{
-			// Loss
-			_turn_win( sn_turnid ^ 0x1U );
-		}
-		else if( foulCondition )
-		{
-			// Foul
-			_turn_foul();
-		}
-		else if( isObjectiveSink && !isOpponentSink )
-		{
-			// Continue
-			_turn_continue();
-		}
-		else
-		{
-			// Pass
-			_turn_pass();
-		}
-	}
-
-	// Check if there was a network update on hold
-	if( sn_updatelock )
-	{
-		#if HT8B_DEBUGGER
-		_frp( FRP_LOW + "Update was waiting, executing now" + FRP_END );
-		#endif
-
-		sn_updatelock = false;
-
-		_netread();
-	}
-}
-
-void _onlocal_timer_end()
-{
-	timer_running = false;
-	
-	#if HT8B_DEBUGGER
-	_frp( FRP_ERR + "Out of time!!" + FRP_END );
-	#endif
-
-	// We are holding the stick so propogate the change
-	if( Networking.GetOwner( playerTotems[ sn_turnid ] ) == Networking.LocalPlayer )
-	{
-		Networking.SetOwner( Networking.LocalPlayer, this.gameObject );
-		_turn_foul();
-	}
-	else
-	{
-		// All local players freeze until next target
-		// can pick up and propogate timer end
-		sn_permit = false;
-	}
-}
-
-
-// Grant cue access if we are playing
-void _apply_cue_access()
-{
-	if( local_playerid >= 0 )
-	{
-		if( gm_practice )
-		{
-			gripControllers[ 0 ]._access_allow();
-			gripControllers[ 1 ]._access_allow();
-		}
-		else
-		{
-			if( (local_teamid & 0x1) > 0 )						// Local player is 1, or 3
-			{
-				gripControllers[ 1 ]._access_allow();
-				gripControllers[ 0 ]._access_deny();
-			}
-			else															// Local player is 0, or 2
-			{
-				gripControllers[ 0 ]._access_allow();
-				gripControllers[ 1 ]._access_deny();
-			}
-		}
-	}
-	else
-	{
-		gripControllers[ 0 ]._access_deny();
-		gripControllers[ 1 ]._access_deny();
-	}
-}
-
-// Some udon specific optimisations
-void _setup_gm_spec()
-{
-	gm_is_0 = sn_gamemode == 0u;
-	gm_is_1 = sn_gamemode == 1u;
-	gm_is_2 = sn_gamemode == 2u;
-}
-
-void _onlocal_newgame()
-{
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + "NewGameLocal()" + FRP_END );
-	#endif
-
-	_setup_gm_spec();
-
-	// Calculate interpreted values from menu states
-	if( local_playerid >= 0 )
-		local_teamid = (uint)local_playerid & 0x1u;
-
-	// Disable menu
-	_htmenu_exit();
-
-	// Reflect menu-state settings (for late joiners)
-	_vis_updatecoloursources();
-	_vis_apply_tablecolour(0);
-	_apply_cue_access();
-
-	// TODO: move to function
-	if( gm_is_1 )	// 9 ball specific
-	{
-		scoreCardRenderer.gameObject.SetActive( false );
-		marker9ball.SetActive( true );
-	}
-	else
-	{
-		scoreCardRenderer.gameObject.SetActive( true );
-		marker9ball.SetActive( false );
-	}
-
-	if( gm_is_2 ) // 4 ball specific
-	{
-		pocketblockers.SetActive( true );
-		scoreCardRenderer.sharedMaterial.SetTexture( "_MainTex", scorecard4ball );
-
-		scoreCardRenderer.sharedMaterial.SetColor( uniform_scorecard_colour0, pColour0 );
-		scoreCardRenderer.sharedMaterial.SetColor( uniform_scorecard_colour1, pColour1 );
-
-		fb_scores[ 0 ] = 0;
-		fb_scores[ 1 ] = 0;
-
-		// Reset mesh filters on balls that change them
-		balls_render[ 0 ].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[ 0 ];
-		balls_render[ 9 ].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[ 1 ];
-	}
-	else
-	{
-		pocketblockers.SetActive( false );
-		scoreCardRenderer.sharedMaterial.SetTexture( "_MainTex", scorecard8ball );
-
-		// Reset mesh filters on balls that change them
-		balls_render[ 0 ].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[ 0 ];
-		balls_render[ 9 ].GetComponent<MeshFilter>().sharedMesh = _9ball_mesh;
-	}
-
-
-	_vis_showballs();
-
-	// Reflect game state
-	_onlocal_updatescorecard();
-	isReposition = false;
-	markerObj.SetActive( false );
-	infBaseTransform.SetActive( false );
-
-	// Effects
-	introAminTimer = 2.0f;
-	aud_main.PlayOneShot( snd_Intro, 1.0f );
-
-	// Player name texts
-	string base_text = "";
-	if( sn_teams )
-	{
-		base_text = "Team ";
-	}
-
-	tableoverlayUI.SetActive( true );
-	playerNames[0].text = base_text + Networking.GetOwner( playerTotems[0] ).displayName;
-	playerNames[1].text = base_text + Networking.GetOwner( playerTotems[1] ).displayName;
-
-	timer_running = false;
-
-	// Switch desktop/vr
-	bool usr_desktop = !Networking.LocalPlayer.IsUserInVR();
-
-	#if !HT_QUEST
-	gripControllers[0].useDesktop = usr_desktop;
-	gripControllers[1].useDesktop = usr_desktop;
-	#endif
-}
-
-#endregion
-
-#region R_PHYS
-
-// Cue input tracking
-
-Vector3	cue_lpos;
-Vector3	cue_llpos;
-Vector3	cue_vdir;
-Vector3	cue_shotdir;
-float		cue_fdir;
-
-#if HT_QUEST
-#else
-public Vector3	dkTargetPos;				// Target for desktop aiming
-#endif
-
-#if !HT_QUEST
-
-// Finalize positions onto their rack spots
-void _vis_rackballs()
-{
-	uint ball_bit = 0x1u;
-
-	for( int i = 0; i < 16; i ++ )
-	{
-		balls_render[ i ].GetComponent< Rigidbody >().isKinematic = true;
-		
-		if( (ball_bit & sn_pocketed) == ball_bit )
-		{
-			balls_render[ i ].transform.localPosition = new Vector3(
-				ball_CO[ i ].x,
-				k_RACK_HEIGHT,
-				ball_CO[ i ].z
-			);
-		}
-
-		ball_bit <<= 1;
-	}
-}
-
-#endif
-
-// Internal game state pocket and enable unity physics to play out the rest
-void _onlocal_pocketball( int id )
-{
-	uint total = 0U;
-
-	// Get total for X positioning
-	int count_extent = gm_is_1? 10: 16;
-	for( int i = 1; i < count_extent; i ++ )
-	{
-		total += (sn_pocketed >> i) & 0x1U;
-	}
-
-	// set this for later
-	ball_CO[ id ].x = -0.9847f + (float)total * k_BALL_DIAMETRE;
-	ball_CO[ id ].z = 0.768f;
-	
-	sn_pocketed ^= 1U << id;
-
-	uint bmask = 0x1FCU << ((int)(sn_turnid ^ sn_playerxor) * 7);
-
-	// Good pocket
-	if( ((0x1U << id) & ((bmask) | (sn_open ? 0xFFFCU: 0x0000U) | ((bmask & sn_pocketed) == bmask? 0x2U: 0x0U))) > 0 )
-	{
-		_onlocal_pocket_obj();
-	}
-	else
-	{
-		// bad
-		_onlocal_pocket_enm();
-	}
-
-	#if !HT_QUEST
-
-	// VFX ( make ball move )
-	Rigidbody body = balls_render[ id ].GetComponent< Rigidbody >();
-	body.isKinematic = false;
-	body.velocity = new Vector3(
-	
-		ball_V[ id ].x,
-		0.0f,
-		ball_V[ id ].z
-		
-	);
-
-	#else
-
-	balls_render[ id ].transform.position = new Vector3(
-
-		ball_CO[ id ].x,
-		k_RACK_HEIGHT,
-		ball_CO[ id ].y
-	
-	);
-	#endif
-}
-
-// Makes sure that velocity is not opposing surface normal
-/*
-void _clamp_ball_vel_semi( int id, Vector2 surface )
-{
-	// TODO: improve this method to be a bit more accurate
-	if( Vector2.Dot( ball_V[ id ], surface ) < 0.0f )
-	{
-		ball_V[ id ] = ball_V[ id ].magnitude * surface;
-	}
-}
-*/
-
-// Is cue touching another ball?
-bool _cue_contacting()
-{
-	// 8 ball, practice, portal
-	if( sn_gamemode != 1u )
-	{
-		// Check all
-		for( int i = 1; i < 16; i ++ )
-		{
-			if( (ball_CO[ 0 ] - ball_CO[ i ]).sqrMagnitude < k_BALL_DSQR )
-			{
-				return true;
-			}
-		}
-	}
-	else // 9 ball
-	{
-		// Only check to 9 ball
-		for( int i = 1; i <= 9; i ++ )
-		{
-			if( (ball_CO[ 0 ] - ball_CO[ i ]).sqrMagnitude < k_BALL_DSQR )
-			{
-				return true;
-			}
-		}
-	}
-
-	return false;
-}
-
-// Check pocket condition
-void _phy_ball_pockets( int id )
-{
-	float zz, zx;
-	Vector3 A;
-
-	A = ball_CO[ id ];
-
-	// Setup major regions
-	zx = Mathf.Sign( A.x );
-	zz = Mathf.Sign( A.z );
-
-	// Its in a pocket
-	if( A.z*zz > k_TABLE_HEIGHT + k_POCKET_DEPTH || A.z*zz > A.x*-zx + k_TABLE_WIDTH+k_TABLE_HEIGHT + k_POCKET_DEPTH )
-	{
-		_onlocal_pocketball( id );
-	}
-}
-
-const float k_SINA = 0.28078832987f;
-const float k_SINA2 = 0.07884208619f;
-const float k_COSA = 0.95976971915f;
-const float k_COSA2 = 0.92115791379f;
-const float k_EP1 = 1.79f;
-const float k_A = 21.875f;
-const float k_B = 6.25f;
-const float k_F = 1.72909790282f;
-
-// Apply cushion bounce
-void _phy_bounce_cushion( int id, Vector3 N )
-{
-	// Mathematical expressions derived from: https://billiards.colostate.edu/physics_articles/Mathavan_IMechE_2010.pdf
-	//
-	// (Note): subscript gamma, u, are used in replacement of Y and Z in these expressions because
-	// unicode does not have them.
-	//
-	// f = 2/7
-	// f₁ = 5/7
-	// 
-	// Velocity delta:
-	//   Δvₓ = −vₓ∙( f∙sin²θ + (1+e)∙cos²θ ) − Rωᵤ∙sinθ
-	//   Δvᵧ = 0
-	//   Δvᵤ = f₁∙vᵤ + fR( ωₓ∙sinθ - ωᵧ∙cosθ ) - vᵤ
-	//
-	// Aux:
-	//   Sₓ = vₓ∙sinθ - vᵧ∙cosθ+ωᵤ
-	//   Sᵧ = 0
-	//   Sᵤ = -vᵤ - ωᵧ∙cosθ + ωₓ∙cosθ
-	//   
-	//   k = (5∙Sᵤ) / ( 2∙mRA ); 
-	//   c = vₓ∙cosθ - vᵧ∙cosθ
-	//
-	// Angular delta:
-	//   ωₓ = k∙sinθ
-	//   ωᵧ = k∙cosθ
-	//   ωᵤ = (5/(2m))∙(-Sₓ / A + ((sinθ∙c∙(e+1)) / B)∙(cosθ - sinθ));
-	//
-	// These expressions are in the reference frame of the cushion, so V and ω inputs need to be rotated
-
-	// Reject bounce if velocity is going the same way as normal
-	// this state means we tunneled, but it happens only on the corner
-	// vertexes
-	Vector3 source_v = ball_V[ id ];
-	if( Vector3.Dot( source_v, N ) > 0.0f )
-	{
-		return;
-	}
-
-	// Rotate V, W to be in the reference frame of cushion
-	Quaternion rq = Quaternion.AngleAxis( Mathf.Atan2( -N.z, -N.x ) * Mathf.Rad2Deg, Vector3.up );
-	Quaternion rb = Quaternion.Inverse( rq );
-	Vector3 V = rq * source_v;
-	Vector3 W = rq * ball_W[ id ];
-	 
-	Vector3 V1; 
-	Vector3 W1;
-	float k, c, s_x, s_z;
-
-	//V1.x = -V.x * ((2.0f/7.0f) * k_SINA2 + k_EP1 * k_COSA2) - (2.0f/7.0f) * k_BALL_PL_X * W.z * k_SINA;
-	//V1.z = (5.0f/7.0f)*V.z + (2.0f/7.0f) * k_BALL_PL_X * (W.x * k_SINA - W.y * k_COSA) - V.z;
-	//V1.y = 0.0f; 
-	// (baked):
-	V1.x = -V.x*k_F - 0.00240675711f*W.z;
-	V1.z = 0.71428571428f*V.z + 0.00857142857f*(W.x*k_SINA-W.y*k_COSA) - V.z;
-	V1.y = 0.0f;
-
-	// s_x = V.x * k_SINA - V.y * k_COSA + W.z;
-	// (baked): y component not used:
-	s_x = V.x * k_SINA + W.z;
-	s_z = -V.z - W.y * k_COSA + W.x * k_SINA; 
-
-	// k = (5.0f * s_z) / ( 2 * k_BALL_MASS * k_A ); 
-	// (baked):
-	k = s_z * 0.71428571428f; 
-
-	// c = V.x * k_COSA - V.y * k_COSA;
-	// (baked): y component not used
-	c = V.x * k_COSA;
-
-	W1.x = k * k_SINA;
-
-	//W1.z = (5.0f / (2.0f * k_BALL_MASS)) * (-s_x / k_A + ((k_SINA * c * k_EP1) / k_B) * (k_COSA - k_SINA));
-	// (baked):
-	W1.z = 15.625f * (-s_x * 0.04571428571f + c * 0.0546021744f);
-	W1.y = k * k_COSA;
-
-	// Unrotate result
-	ball_V[ id ] += rb * V1;
-	ball_W[ id ] += rb * W1;
-}
-
-// Pocketless table
-void _phy_ball_table_carom( int id )
-{
-	float zz, zx;
-	Vector3 A;
-
-	A = ball_CO[ id ];
-
-	// Setup major regions
-	zx = Mathf.Sign( A.x );
-	zz = Mathf.Sign( A.z );
-
-	if( A.x * zx > k_TABLE_WIDTH )
-	{
-		ball_CO[ id ].x = k_TABLE_WIDTH * zx;
-		_phy_bounce_cushion( id, Vector3.left * zx );
-	}
-
-	if( A.z * zz > k_TABLE_HEIGHT )
-	{
-		ball_CO[ id ].z = k_TABLE_HEIGHT * zz;
-		_phy_bounce_cushion( id, Vector3.back * zz );
-	}
-}
-
-// TODO: inline this
-// Xiexe: I think that this is a rather cursed way to handle table edge collision detections and I think there's maybe a less cursed way to do it.
-void _phy_ball_table_std( int id )
-{
-	float zy, zx, zk, zw, d, k, i, j, l, r;
-	Vector3 A, N;
-
-	A = ball_CO[ id ];
-
-	// REGIONS
-	/*  
-		*  QUADS:							SUBSECTION:				SUBSECTION:
-		*    zx, zy:							zz:						zw:
-		*																
-		*  o----o----o  +:  1			\_________/				\_________/
-		*  | -+ | ++ |  -: -1		     |	    /		              /  /
-		*  |----+----|					  -  |  +   |		      -     /   |
-		*  | -- | +- |						  |	   |		          /  +  |
-		*  o----o----o						  |      |             /       |
-		* 
-		*/
-
-	// Setup major regions
-	zx = Mathf.Sign( A.x );
-	zy = Mathf.Sign( A.z );
-
-	// within pocket regions
-	if( (A.z*zy > (k_TABLE_HEIGHT-k_POCKET_RADIUS)) && (A.x*zx > (k_TABLE_WIDTH-k_POCKET_RADIUS) || A.x*zx < k_POCKET_RADIUS) )
-	{
-		// Subregions
-		zw = A.z * zy > A.x * zx - k_TABLE_WIDTH + k_TABLE_HEIGHT ? 1.0f : -1.0f;
-
-		// Normalization / line coefficients change depending on sub-region
-		if( A.x * zx > k_TABLE_WIDTH * 0.5f )
-		{
-			zk = 1.0f;
-			r = k_1OR2;
-		}
-		else
-		{
-			zk = -2.0f;
-			r = k_1OR5;
-		}
-
-		// Collider line EQ
-		d = zx * zy * zk; // Coefficient
-		k = (-(k_TABLE_WIDTH * Mathf.Max(zk, 0.0f)) + k_POCKET_RADIUS * zw * Mathf.Abs( zk ) + k_TABLE_HEIGHT) * zy; // Konstant
-
-		// Check if colliding
-		l = zw * zy;
-		if( A.z * l > (A.x * d + k) * l )
-		{
-			// Get line normal
-			N.x = zx * zk;
-			N.z = -zy;
-			N.y = 0.0f;
-			N *= zw * r;
-
-			// New position
-			i = (A.x * d + A.z - k) / (2.0f * d);
-			j = i * d + k;
-
-			ball_CO[ id ].x = i;
-			ball_CO[ id ].z = j;
-
-			// Reflect velocity
-			_phy_bounce_cushion( id, N );
-		}
-	}
-	else // edges
-	{
-		if( A.x * zx > k_TABLE_WIDTH )
-		{
-			ball_CO[ id ].x = k_TABLE_WIDTH * zx;
-			_phy_bounce_cushion( id, Vector3.left * zx );
-		}
-
-		if( A.z * zy > k_TABLE_HEIGHT )
-		{
-			ball_CO[ id ].z = k_TABLE_HEIGHT * zy;
-			_phy_bounce_cushion( id, Vector3.back * zy );
-		}
-	}
-}
-
-// Advance simulation 1 step for ball id
-void _phy_ball_step( int id )
-{
-	// Since v1.5.0
-	Vector3 V = ball_V[ id ];
-	Vector3 W = ball_W[ id ];
-	Vector3 cv;
-
-	// Equations derived from: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.89.4627&rep=rep1&type=pdf
-	// 
-	// R: Contact location with ball and floor aka: (0,-r,0)
-	// µₛ: Slipping friction coefficient
-	// µᵣ: Rolling friction coefficient
-	// i: Up vector aka: (0,1,0)
-	// g: Planet Earth's gravitation acceleration ( 9.80665 )
-	// 
-	// Relative contact velocity (marlow):
-	//   c = v + R✕ω
-	//
-	// Ball is classified as 'rolling' or 'slipping'. Rolling is when the relative velocity is none and the ball is
-	// said to be in pure rolling motion
-	//
-	// When ball is classified as rolling:
-	//   Δv = -µᵣ∙g∙Δt∙(v/|v|)
-	//
-	// Angular momentum can therefore be derived as:
-	//   ωₓ = -vᵤ/R
-	//   ωᵧ =  0
-	//   ωᵤ =  vₓ/R
-	//
-	// In the slipping state:
-	//   Δω = ((-5∙µₛ∙g)/(2/R))∙Δt∙i✕(c/|c|)
-	//   Δv = -µₛ∙g∙Δt(c/|c|)
-
-	// Relative contact velocity of ball and table
-	cv = V + Vector3.Cross( k_CONTACT_POINT, W );
-	
-	// Rolling is achieved when cv's length is approaching 0
-	// The epsilon is quite high here because of the fairly large timestep we are working with
-	if( cv.magnitude <= 0.1f )
-	{
-		//V += -k_F_ROLL * k_GRAVITY * k_FIXED_TIME_STEP * V.normalized;
-		// (baked):
-		V += -0.00122583125f * V.normalized;
-
-		// Calculate rolling angular velocity
-		W.x = -V.z * k_BALL_1OR;
-		W.y =  0.0f;
-		W.z =  V.x * k_BALL_1OR;
-
-		// Stopping scenario
-		if( V.magnitude < 0.01f && W.magnitude < 0.2f )
-		{
-			W = Vector3.zero;
-			V = Vector3.zero;
-		}
-		else
-		{
-			ballsMoving = true;
-		}
-	}
-	else // Slipping
-	{
-		Vector3 nv = cv.normalized;
-
-		// Angular slipping friction
-		//W += ((-5.0f * k_F_SLIDE * 9.8f)/(2.0f * 0.03f)) * k_FIXED_TIME_STEP * Vector3.Cross( Vector3.up, nv );
-		// (baked):
-		W += -2.04305208f * Vector3.Cross( Vector3.up, nv );
-		V += -k_F_SLIDE * 9.8f * k_FIXED_TIME_STEP * nv;
-
-		ballsMoving = true;
-	}
-
-	ball_W[ id ] = W;
-	ball_V[ id ] = V;
-	balls_render[ id ].transform.Rotate( W.normalized, W.magnitude * k_FIXED_TIME_STEP * -Mathf.Rad2Deg, Space.World );
-
-	uint ball_bit = 0x1U << id;
-
-	// ball/ball collisions
-	for( int i = id+1; i < 16; i ++ )
-	{
-		ball_bit <<= 1;
-
-		if( (ball_bit & sn_pocketed) != 0U )
-			continue;
-
-		Vector3 delta = ball_CO[ i ] - ball_CO[ id ];
-		float dist = delta.magnitude;
-
-		if( dist < k_BALL_DIAMETRE )
-		{
-			// Physics shit
-
-			Vector3 normal = delta / dist;
-
-			Vector3 velocityDelta = ball_V[ id ] - ball_V[ i ];
-
-			float dot = Vector3.Dot( velocityDelta, normal );
-
-			if( dot > 0.0f ) 
-			{
-				Vector3 reflection = normal * dot;
-				ball_V[id] -= reflection;
-				ball_V[i] += reflection;
-
-				// Prevent sound spam if it happens
-				if( ball_V[ id ].sqrMagnitude > 0 && ball_V[ i ].sqrMagnitude > 0 )
-				{
-					int clip = UnityEngine.Random.Range(0, snd_Hits.Length - 1);
-					float vol = Mathf.Clamp01(ball_V[id].magnitude * reflection.magnitude);
-					ball_AudioPool[id].transform.position = balls_render[id].transform.position;
-					ball_AudioPool[id].PlayOneShot(snd_Hits[clip], vol);
-				}
-
-				// First hit detected
-				if( id == 0 )
-				{
-					if( gm_is_2 )
-					{
-						if( fb_kr )	// KR 사구 ( Sagu )
-						{
-							if( i == 9 )
-							{
-								if( !fb_madefoul )
-								{
-									_onlocal_carompenalize( ball_CO[ i ] );
-								}
-							}
-							else
-							{
-								if( sn_firsthit == 0 )
-								{
-									sn_firsthit = i;
-								}
-								else
-								{
-									if( i != sn_firsthit )
-									{
-										if( sn_secondhit == 0 )
-										{
-											sn_secondhit = i;
-											_onlocal_carompoint( ball_CO[ i ] );
-										}
-									}
-								}
-							}
-						}
-						else // JP 四つ玉 ( Yotsudama )
-						{
-							if( sn_firsthit == 0 )
-							{
-								sn_firsthit = i;
-							}
-							else
-							{
-								if( sn_secondhit == 0 )	
-								{
-									if( i != sn_firsthit )
-									{
-										sn_secondhit = i;
-										_onlocal_carompoint( ball_CO[ i ] );
-									}
-								}
-								else 
-								{
-									if( sn_thirdhit == 0 )
-									{
-										if( i != sn_firsthit && i != sn_secondhit )
-										{
-											sn_thirdhit = i;
-											_onlocal_carompoint( ball_CO[ i ] );
-										}
-									}
-								}
-							}
-						}
-					}
-					else
-					{
-						if( sn_firsthit == 0 )
-						{
-							sn_firsthit = i;
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-// ( Since v0.2.0a ) Check if we can predict a collision before move update happens to improve accuracy
-bool _phy_predict_cueball()
-{
-	// Get what will be the next position
-	Vector3 originalDelta = ball_V[ 0 ] * k_FIXED_TIME_STEP;
-	Vector3 norm = ball_V[ 0 ].normalized;
-	
-	Vector3 h;
-	float lf, s, nmag;
-
-	// Closest found values
-	float minlf = 9999999.0f;
-	int minid = 0;
-	float mins = 0;
-
-	uint ball_bit = 0x1U;
-
-	// Loop balls look for collisions
-	for( int i = 1; i < 16; i ++ )
-	{
-		ball_bit <<= 1;
-
-		if( (ball_bit & sn_pocketed) != 0U )
-			continue;
-
-		h = ball_CO[ i ] - ball_CO[ 0 ];
-		lf = Vector3.Dot( norm, h );
-		s = k_BALL_DSQRPE - Vector3.Dot( h, h ) + lf * lf;
-
-		if( s < 0.0f )
-			continue;
-
-		if( lf < minlf )
-		{
-			minlf = lf;
-			minid = i;
-			mins = s;
-		}
-	}
-
-	if( minid > 0 )
-	{
-		nmag = minlf-Mathf.Sqrt( mins );
-
-		// Assign new position if got appropriate magnitude
-		if( nmag * nmag < originalDelta.sqrMagnitude )
-		{
-			ball_CO[ 0 ] += norm * nmag;
-			return true;
-		}
-	}
-
-	return false;
-}
-
-// Run one physics iteration for all balls
-void _phys_step()
-{
-#if !COMPILE_FUNC_TESTS
-	ballsMoving = false;
-#else
-	ballsMoving = true;
-#endif
-
-	uint ball_bit = 0x1u;
-
-	// Cue angular velocity
-	if( (sn_pocketed & 0x1U) == 0 )
-	{
-
-		if( !_phy_predict_cueball() )
-		{
-			// Apply movement
-			ball_CO[ 0 ] += ball_V[ 0 ] * k_FIXED_TIME_STEP;
-		}
-
-		_phy_ball_step( 0 );
-	}
-
-	// Run main simulation / inter-ball collision
-	for( int i = 1; i < 16; i ++ )
-	{
-		ball_bit <<= 1;
-
-		if( (ball_bit & sn_pocketed) == 0U )
-		{
-			ball_CO[ i ] += ball_V[ i ] * k_FIXED_TIME_STEP;
-			
-			_phy_ball_step( i );
-		}
-	}
-
-	// Check if simulation has settled
-	if( !ballsMoving )
-	{
-		if( sn_simulating )
-		{
-			_onlocal_sim_end();
-		}
-
-		return;
-	}
-
-	if( gm_is_2 )
-	{
-		_phy_ball_table_carom( 0 );
-		_phy_ball_table_carom( 2 );
-		_phy_ball_table_carom( 3 );
-		_phy_ball_table_carom( 9 );
-	}
-	else
-	{
-		ball_bit = 0x1U;
-
-		// Run edge collision
-		for( int i = 0; i < 16; i ++ )
-		{
-			if( (ball_bit & sn_pocketed ) == 0U )
-				_phy_ball_table_std( i );
-		
-			ball_bit <<= 1;
-		}
-	}
-
-	if( gm_is_2 ) return;
-
-	ball_bit = 0x1U;
-
-	// Run triggers
-	for( int i = 0; i < 16; i ++ )
-	{
-		if( (ball_bit & sn_pocketed ) == 0U )
-		{
-			_phy_ball_pockets( i );
-		}
-
-		ball_bit <<= 1;
-	}
-}
-
-// Ray circle intersection
-// yes, its fixed size circle
-// Output is dispensed into the below variable
-// One intersection point only
-// This is not used in physics calcuations, only cue input
-
-Vector2 RayCircle_output;
-bool _phy_ray_circle( Vector2 start, Vector2 dir, Vector2 circle )
-{
-	Vector2 nrm = dir.normalized;
-	Vector2 h = circle - start;
-	float lf = Vector2.Dot( nrm, h );
-	float s = k_BALL_RSQR - Vector2.Dot( h, h ) + lf * lf;
-
-	if( s < 0.0f ) return false;
-
-	s = Mathf.Sqrt( s );
-
-	if( lf < s )
-	{
-		if( lf + s >= 0 )
-		{
-			s = -s;
-		}
-		else
-		{
-			return false;
-		}
-	}
-
-	RayCircle_output = start + nrm * (lf-s);
-	return true;
-}
-
-Vector3 RaySphere_output;
-bool _phy_ray_sphere( Vector3 start, Vector3 dir, Vector3 sphere )
-{
-	Vector3 nrm = dir.normalized;
-	Vector3 h = sphere - start;
-	float lf = Vector3.Dot( nrm, h );
-	float s = k_BALL_RSQR - Vector3.Dot(h, h) + lf * lf;
-
-	if( s < 0.0f ) return false;
-
-	s = Mathf.Sqrt( s );
-
-	if( lf < s )
-	{
-		if( lf + s >= 0 )
-		{
-			s = -s;
-		}
-		else
-		{
-			return false;
-		}
-	}
-
-	RaySphere_output = start + nrm * (lf-s);
-	return true;
-}
-
-// Closest point on line from pos
-Vector2 _line_project( Vector2 start, Vector2 dir, Vector2 pos )
-{
-	return start + dir * Vector2.Dot( pos - start, dir );
-}
-#endregion
-
-#region R_UTIL
-
-// Find the lowest numbered ball, that isnt the cue, on the table
-// This function finds the VISUALLY represented lowest ball,
-// since 8 has id 1, the search needs to be split
-int _lowest_ball( uint field )
-{
-	for( int i = 2; i <= 8; i ++ )
-	{
-		if( ((field >> i) & 0x1U) == 0x00U )
-			return i;
-	}
-
-	if( ((field) & 0x2U) == 0x00U )
-		return 1;
-
-	for( int i = 9; i < 16; i ++ )
-	{
-		if( ((field >> i) & 0x1U) == 0x00U )
-			return i;
-	}
-
-	// ??
-	return 0;
-}
-
-#endregion
-
-#region R_TURNRULES
-
-void _turn_win( uint winner )
-{
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + " -> GAMEOVER" + FRP_END );
-	#endif
-
-	sn_gameover = true;
-	sn_winnerid = winner;
-
-	_netpack( sn_turnid );
-	_netread();
-
-	_onlocal_gameover();
-}
-
-void _turn_pass()
-{
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + " -> PASS" + FRP_END );
-	#endif
-
-	sn_permit = true;
-
-	_netpack( sn_turnid ^ 0x1u );
-	_netread();
-}
-
-void _turn_foul()
-{
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + " -> FOUL" + FRP_END );
-	#endif
-
-	sn_foul = true;
-	sn_permit = true;
-
-	_netpack( sn_turnid ^ 0x1U );
-	_netread();
-}
-
-void _turn_continue()
-{
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + " -> COTNINUE" + FRP_END );
-	#endif
-
-	// Close table if it was open ( 8 ball specific )
-	if( gm_is_0 )
-	{
-		if( sn_open )
-		{
-			uint sink_orange = 0;
-			uint sink_blue = 0;
-			uint pmask = sn_pocketed >> 2;
-
-			for( int i = 0; i < 7; i ++ )
-			{
-				if( (pmask & 0x1u) == 0x1u )
-					sink_blue ++;
-
-				pmask >>= 1;
-			}
-			for( int i = 0; i < 7; i ++ )
-			{
-				if( (pmask & 0x1u) == 0x1u )
-					sink_orange ++;
-
-				pmask >>= 1;
-			}
-
-			if( sink_blue == sink_orange )
-			{
-				// Sunk equal amounts therefore still undecided
-			}
-			else
-			{
-				if( sink_blue > sink_orange )
-				{
-					sn_playerxor = sn_turnid;
-				}
-				else
-				{
-					sn_playerxor = sn_turnid ^ 0x1u;
-				}
-
-				sn_open = false;
-				_onlocal_tableclosed();
-			}
-		}
-	}
-
-	// Keep playing
-	sn_permit = true;
-
-	_netpack( sn_turnid );
-	_netread();
-}
-
-#endregion
-
-#region R_MENU
-
-						Vector3		m_planenormal;
-						float			m_planedist;
-
-						Vector3		m_cursor;
-						bool			m_desktop			= true;
-
-			const		float			k_mGmButtonW		= 0.09345f;
-			const		float			k_mGmButtonH		= 0.034f;
-			const		float			k_mSmolButtonR		= 0.034f;
-
-			const 	float			k_mGmButtonA		= 0.01026977f;		// Reset height
-
-[SerializeField]	GameObject[]	m_gamemode_buttons;
-[SerializeField]	GameObject[]	m_join_buttons;
-						
-//[SerializeField]	GameObject		m_startbutton;
-[SerializeField]	GameObject[]	m_teambuttons;
-[SerializeField]	GameObject[]	m_timebuttons;
-
-						bool[]			m_gm_buttonstates = new bool[4];
-[SerializeField]	Mesh[]			m_buttonmeshes;
-
-				const int				k_EButtonMesh_8ball		= 0;
-				const int				k_EButtonMesh_9ball		= 1;
-				const int				k_EButtonMesh_4ball		= 2;
-				const int				k_EButtonMesh_reserved0 = 3;
-				const int				k_EButtonMesh_green		= 4;
-				const int				k_EButtonMesh_red			= 5;
-				const int				k_EButtonMesh_blue		= 6;
-				const int				k_EButtonMesh_triangle	= 7;
-				const int				k_EButtonMesh_join_0		= 8;
-				const int				k_EButtonMesh_join_1		= 9;
-				const int				k_EButtonMesh_play		= 10;
-
-				const uint				k_ButtonState_None			= 0x0u;
-				const uint				k_ButtonState_Pressing		= 0x1u;
-				const uint				k_ButtonState_Triggered		= 0x2u;
-				const uint				k_ButtonState_ShouldReset	= 0x2u;
-				const uint				k_ButtonState_FrameMask		= 0xFFFFFFFEu; // (~0x1u)
-
-				// Current check dimensions ( pulled from above )
-				float	m_current_x = 0.0f;
-				float	m_current_y = 0.0f;
-				Mesh	m_current_outline;
-				MeshFilter	m_outline_filter;
-
-				uint[]			m_auto_btnstate = new uint[20];
-				GameObject[]	m_auto_btnobjs	= new GameObject[20];
-				int				m_auto_id		= -1;
-
-[SerializeField]	GameObject		m_gm_dkoutline;
-[SerializeField]	GameObject[]	m_playerslot_owners;
-
-				// VFX stuff
-[SerializeField]	GameObject		m_TeamCover;
-[SerializeField]	GameObject		m_TimeLimitDisp;
-
-				Vector3					m_TeamCover_target_s;
-				Vector3					m_TeamCover_current_s;
-
-				Vector3					m_TimeLimit_x_target;
-				Vector3					m_TimeLimit_x_current;
-
-[SerializeField]	GameObject		m_menuLoc_main;
-[SerializeField]	GameObject		m_menuLoc_start;
-[SerializeField]	GameObject		m_newGameBtn;
-[SerializeField]	Text[]			m_lobbyNames;
-[SerializeField]	GameObject[]	rulePages;
-
-				Vector3					m_menuLoc_sw;
-				Vector3					m_menuLoc_swt;
-
-VRCPlayerApi localplayer;
+    // Audio Components
+    private AudioSource mainSrc;
+
+    [UdonSynced] private string newState;     // dumpster fire
+    private string oldState;
+
+    byte[] networkData = new byte[0x52];
+
+    // Networked gamestate
+    //  data positions are marked as <#ushort>:<#bit> (<hexmask>) <description>S
+
+    public bool gameIsSimulating = false;      // 19:0 (0x01)		True whilst balls are rolling
+    public uint timerType = 0; // 19:13 (0x6000)	Timer ID 2 bit		{ 0: inf, 1: 10s, 2: 15s, 3: 30s, 4: 60s, 5: undefined }
+    public bool isPlayerAllowedToPlay = false;      // 19:7 (0x80)		Permission for player to play
+    public uint gameMode = 0;   // 19:8 (0x700)	Gamemode ID 3 bit	{ 0: 8 ball, 1: 9 ball, 2+: undefined }
+
+    private uint ballPocketedState = 0x00U;       // 18:0 (0xffff)	Each bit represents each ball, if it has been pocketed or not
+    private uint turnID = 0x00U;     // 19:1 (0x02)		Whos turn is it, 0 or 1
+    private bool isFoul = false;       // 19:2 (0x04)		End-of-turn foul marker
+    private bool isOpen = true;        // 19:3 (0x08)		Is the table open?
+    private uint playerColours = 0x00;       // 19:4 (0x10)		What colour the players have chosen
+    private bool isGameOver = true;        // 19:5 (0x20)		Game is complete
+    private uint winnerID = 0x00U;       // 19:6 (0x40)		Who won the game if sn_gameover is set
+    private bool isLobbyClosed = true;
+    private bool isTeams = false;  // 19:15 (0x8000)	Teams on/off (1 bit)
+    private ushort clock = 0;         // 20:0 (0xffff)	Current packet number, used for locking updates so we dont accidently go back.
+                                      //							this behaviour was observed on some long connections so its necessary
+    private ushort gameID = 0;           // 21:0 (0xffff)	Game number
+    private ushort modeSpecficData = 0;           // 22:0 (0xffff)	Game mode specific information
+
+    // Cannot making a struct in C#, therefore values are duplicated
+
+    // for gamestate deltas
+    private uint oldPocketed;
+    private uint oldTurnID;
+    private bool oldOpen;
+    private bool oldGameOver;
+    private ushort oldGameID;
+
+    private uint oldGameMode;
+    private uint oldTimer;
+    private bool oldTeams;
+    private bool oldLobbyClosed;
+
+    // Local gamestates
+    [HideInInspector]
+    public bool isArmed = false;       // Player is hitting
+    private bool isUpdateLocked = false;     // We are waiting for our local simulation to finish, before we unpack data
+    private int isFirstHit = 0;            // The first ball to be hit by cue ball
+
+    private int isSecondHit = 0;
+    private int isThirdHit = 0;
+
+    private bool isSimulatedByUs = false;     // If the simulation was initiated by us, only set from update
+
+    private byte sn_wins0 = 0;          // Wins for player 0 (unused)
+    private byte sn_wins1 = 0;          // Wins for player 1 (unused)
+
+    private float introAminTimer = 0.0f;        // Ball dropper timer
+
+    private bool ballsMoving = false;       // Tracker variable to see if balls are still on the go
+
+    private bool isReposition = false;          // Repositioner is active
+    private float repoMaxX = TABLE_WIDTH; // For clamping to table or set lower for kitchen
+
+    private float timerEnd = 0.0f;     // What should the timer run out at
+    private float timerRecp = 0.0f;       // 1 over time limit
+    private bool isTimerRunning = false;
+
+    private bool isParticleAlive = false;
+    private float particleTime = 0.0f;
+
+    private bool isMadePoint = false;
+    private bool isMadeFoul = false;
+
+    private bool isJapanese = false;
+    private bool isKorean = false;
+
+    private int[] scores = new int[2];
+
+    private bool isGameModeZero = false;
+    private bool isGameModeOne = false;
+    private bool isGameModeTwo = false;
+    private bool isGameModePractice = false;           // Game should run in practice mode
+    private bool isRegionSelected = false;
+
+    private bool isDesktopShootUI = false;
+
+    // Values that will get sucked in from the menu
+    public int localPlayerID = -1;
+    private uint localTeamID = 0u;     // Interpreted value
+
+    public Vector3[] ball_CO = new Vector3[16];    // Current positions
+    public Vector3[] ball_V = new Vector3[16]; // Current velocities
+    public Vector3[] ball_W = new Vector3[16]; // Angular velocities
+
+    private Color tableSrcColour = new Color(1.0f, 1.0f, 1.0f, 1.0f);   // Runtime target colour
+    private Color tableCurrentColour = new Color(1.0f, 1.0f, 1.0f, 1.0f);   // Runtime actual colour
+
+    // 'Pointer' colours.
+    private Color pointerColour0;     // Team 0
+    private Color pointerColour1;     // Team 1
+    private Color pointerColour2;     // No team / open / 9 ball
+    private Color pointerColourErr;
+    private Color pointerClothColour;
+
+    private Vector3 deskTopCursor = new Vector3(0.0f, 2.0f, 0.0f);
+    private Vector3 desktopHitCursor = new Vector3(0.0f, 0.0f, 0.0f);
+
+    public GameObject desktopCursorObject;
+    public GameObject desktopHitPosition;
+    public GameObject desktopBase;
+    public GameObject desktopQuad;
+    public GameObject[] desktopStickBases;
+    public GameObject desktopOverlayPower;
+    public GameObject dE;
+
+    bool isDesktopShootingIn = false;
+    bool isDesktopSafeRemove = true;
+    Vector3 desktopShootVector;
+    Vector3 desktopSafeRemovePoint;
+    float desktopShootReference = 0.0f;
+    float desktopClampX = TABLE_WIDTH;
+    float desktopClampY = TABLE_HEIGHT;
+    bool isTurnLocalLive = false;
+
+    bool isDesktopFrameIgnore = false;
+
+    // Cue input tracking
+    Vector3 cueLPos;
+    Vector3 cueLLPos;
+    Vector3 cueVDir;
+    Vector3 cueShotDir;
+    float cueFDir;
+
+    Vector3 m_planenormal;
+    float m_planedist;
+
+    Vector3 m_cursor;
+    bool m_desktop = true;
+
+    const float mGmButtonW = 0.09345f;
+    const float mGmButtonH = 0.034f;
+    const float mSmolButtonR = 0.034f;
+
+    const float mGmButtonA = 0.01026977f;     // Reset height
+
+    public GameObject[] m_gamemode_buttons;
+    public GameObject[] m_join_buttons;
+
+    public GameObject[] m_teambuttons;
+    public GameObject[] m_timebuttons;
+
+    bool[] m_gm_buttonstates = new bool[4];
+    public Mesh[] m_buttonmeshes;
+
+    const int EButtonMesh_8ball = 0;
+    const int EButtonMesh_9ball = 1;
+    const int EButtonMesh_4ball = 2;
+    const int EButtonMesh_reserved0 = 3;
+    const int EButtonMesh_green = 4;
+    const int EButtonMesh_red = 5;
+    const int EButtonMesh_blue = 6;
+    const int EButtonMesh_triangle = 7;
+    const int EButtonMesh_join_0 = 8;
+    const int EButtonMesh_join_1 = 9;
+    const int EButtonMesh_play = 10;
+
+    const uint ButtonState_None = 0x0u;
+    const uint ButtonState_Pressing = 0x1u;
+    const uint ButtonState_Triggered = 0x2u;
+    const uint ButtonState_ShouldReset = 0x2u;
+    const uint ButtonState_FrameMask = 0xFFFFFFFEu; // (~0x1u)
+
+    // Current check dimensions ( pulled from above )
+    float m_current_x = 0.0f;
+    float m_current_y = 0.0f;
+    Mesh m_current_outline;
+    MeshFilter m_outline_filter;
+
+    uint[] m_auto_btnstate = new uint[20];
+    GameObject[] m_auto_btnobjs = new GameObject[20];
+    int m_auto_id = -1;
+
+    public GameObject m_gm_dkoutline;
+    public GameObject[] m_playerslot_owners;
+
+    // VFX stuff
+    public GameObject m_TeamCover;
+    public GameObject m_TimeLimitDisp;
+
+    Vector3 m_TeamCover_target_s;
+    Vector3 m_TeamCover_current_s;
+
+    Vector3 m_TimeLimit_x_target;
+    Vector3 m_TimeLimit_x_current;
+
+    public GameObject m_menuLoc_main;
+    public GameObject m_menuLoc_start;
+    public GameObject m_newGameBtn;
+    public Text[] m_lobbyNames;
+    public GameObject[] rulePages;
+
+    Vector3 m_menuLoc_sw;
+    Vector3 m_menuLoc_swt;
+
+    VRCPlayerApi localplayer;
 
 #if MENU_DEV
 
-[SerializeField]	GameObject	m_devcursor;
+    public GameObject m_devcursor;
 
 #endif
 
-Vector3 _plane_line_intersect( Vector3 n, float d, Vector3 a, Vector3 b )
-{
-    Vector3 ba = b-a;
-    float nDotA = Vector3.Dot(n, a);
-    float nDotBA = Vector3.Dot(n, ba);
-
-    return a + (((d - nDotA)/nDotBA) * ba);
-}
-
-// Setup meshes on gameobject
-void _htbtn_init( GameObject button, int variant, bool state )
-{
-	button.GetComponent< MeshFilter >().sharedMesh = m_buttonmeshes[ variant*3 + (state? 1: 0) ];
-}
-
-void _htmenu_init()
-{
-	// Setup button meshes
-	_htbtn_init( m_gamemode_buttons[ 0 ], k_EButtonMesh_8ball, sn_gamemode == 0u );
-	_htbtn_init( m_gamemode_buttons[ 1 ], k_EButtonMesh_9ball, sn_gamemode == 1u );
-	_htbtn_init( m_gamemode_buttons[ 2 ], k_EButtonMesh_4ball, sn_gamemode == 2u );
-
-	_htbtn_init( m_join_buttons[ 0 ], k_EButtonMesh_join_0, false );
-	_htbtn_init( m_join_buttons[ 1 ], k_EButtonMesh_join_1, false );
-
-	//_htbtn_init( m_startbutton, k_EButtonMesh_play, false );
-
-	_htbtn_init( m_teambuttons[ 0 ], k_EButtonMesh_red,	!sn_teams );
-	_htbtn_init( m_teambuttons[ 1 ], k_EButtonMesh_green,  sn_teams );
-
-	_htbtn_init( m_timebuttons[ 0 ], k_EButtonMesh_triangle, true );
-	_htbtn_init( m_timebuttons[ 1 ], k_EButtonMesh_triangle, true );
-	_htbtn_init( m_newGameBtn, k_EButtonMesh_play, true );
-	 
-	m_outline_filter = m_gm_dkoutline.GetComponent<MeshFilter>();
-
-	// Create surface plane
-	m_planenormal = m_base.transform.up;
-	m_planedist = Vector3.Dot( m_base.transform.position, m_planenormal );
-
-	localplayer = Networking.LocalPlayer;
-
-	m_gm_dkoutline.SetActive( false );
-
-	sn_lobbyclosed = true;
-	_htmenu_viewtimer();
-	_htmenu_viewteams();
-	_htmenu_viewgm();
-	_htmenuview();
-}
-
-// View gamemode changes
-void _htmenu_viewgm()
-{
-	for( int i = 0; i < m_gamemode_buttons.Length; i ++ )
-	{
-		if( sn_gamemode == (uint)i )
-		{
-			m_gamemode_buttons[ i ].GetComponent< MeshFilter >().sharedMesh = m_buttonmeshes[ (k_EButtonMesh_8ball + i) * 3 + 1 ];
-		}
-		else
-		{
-			m_gamemode_buttons[ i ].GetComponent< MeshFilter >().sharedMesh = m_buttonmeshes[ (k_EButtonMesh_8ball + i) * 3 ];
-		}
-	}
-}
-
-void _htmenu_viewjoin()
-{
-	int playernum = 0;
-
-	if( !sn_lobbyclosed )
-	{
-		VRCPlayerApi host = Networking.GetOwner( m_playerslot_owners[ 0 ] );
-
-		// Check out player names
-		for( int i = 0; i < (sn_teams? 4: 2); i ++ )
-		{
-			VRCPlayerApi player = Networking.GetOwner( m_playerslot_owners[ i ] );
-
-			// Mark host
-			if( i == 0 )
-			{
-				m_lobbyNames[ i ].text = "<color=\"#f2ecb8\">"+player.displayName+"</color>";
-				playernum ++;
-			}
-			else
-			{
-				// Its us
-				if( local_playerid == i )
-				{
-					// Error: Local believes that we are in lobby, but someone else is there
-					if( player.playerId != Networking.LocalPlayer.playerId )
-					{
-						#if HT8B_DEBUGGER
-						_frp( FRP_ERR + "Error: de-sync local lobby status" + FRP_END );
-						#endif
-
-						local_playerid = -1;
-						m_lobbyNames[ i ].text = "<color=\"#ff0000\">ERROR</color>";
-					}
-					else
-					{
-						playernum ++;
-						m_lobbyNames[ i ].text = "<color=\"#cae4ed\">"+player.displayName+"</color>";
-					}
-				}
-				else
-				{
-					// Player is joined
-					if( host.playerId != player.playerId )
-					{
-						m_lobbyNames[ i ].text = "<color=\"#ffffff\">"+player.displayName+"</color>";
-						playernum ++;
-					}
-					else
-					{
-						m_lobbyNames[ i ].text = "";
-					}
-				}
-			}
-		}
-	}
-
-	gm_practice = local_playerid == 0 && playernum == 1;
-
-	// If in the game
-	if( local_playerid >= 0 )
-	{
-		// Set our team button to the 'leave' button
-		_htbtn_init( m_join_buttons[ local_teamid ], k_EButtonMesh_join_0 + (int)local_teamid, true );
-
-		// Opposite button should become startgame/disabled, 'enabled' if player 0
-		if( local_playerid == 0 )
-		{
-			m_join_buttons[ 1 ].SetActive( true );
-			_htbtn_init( m_join_buttons[ 1 ], k_EButtonMesh_play, true );
-		}
-		else
-		{
-			m_join_buttons[ local_teamid ^ 0x1u ].SetActive( false );
-		}
-	}
-	else // Otherwise, its just join buttons
-	{
-		m_join_buttons[ 0 ].SetActive( true );
-		m_join_buttons[ 1 ].SetActive( true );
-		_htbtn_init( m_join_buttons[ 0 ], k_EButtonMesh_join_0, false );
-		_htbtn_init( m_join_buttons[ 1 ], k_EButtonMesh_join_1, false );
-	}
-}
-
-uint last_viewtimer = 0u;
-bool sound_spinning = false;
-
-void _htmenu_viewtimer()
-{
-	if( last_viewtimer != sn_timer )
-	{
-		aud_main.PlayOneShot( snd_spin );
-		last_viewtimer = sn_timer;
-		sound_spinning = true;
-	}
-
-	m_TimeLimit_x_target = new Vector3( -0.128f * (float)sn_timer, 0.0f, 0.0f );
-}
-
-void _htmenu_viewteams()
-{
-	m_TeamCover_target_s = sn_teams? new Vector3(0,1,1): new Vector3(1,1,1);
-	_htbtn_init( m_teambuttons[ 0 ], k_EButtonMesh_red,  !sn_teams );
-	_htbtn_init( m_teambuttons[ 1 ], k_EButtonMesh_green, sn_teams );
-
-	_htmenu_viewjoin();
-}
-
-void _htmenuview()
-{
-	if( sn_lobbyclosed )
-	{
-		m_menuLoc_swt = Vector3.one;
-	}
-	else
-	{
-		m_menuLoc_swt = Vector3.zero;
-	}
-}
-
-uint	gm_target		= 0u;
-float	gm_minheight	= Mathf.Infinity;
-
-bool _buttonpressed( GameObject btn, int typeid )
-{
-	// Set automatic id's 
-	m_auto_id ++;
-	m_auto_btnobjs[ m_auto_id ] = btn;
-
-	Vector3 delta; Vector3 tmp_pos;
-	delta = btn.transform.localPosition - m_cursor;
-
-	if( Mathf.Abs( delta.x ) < m_current_x && Mathf.Abs( delta.z ) <  m_current_y )
-	{
-		if( m_desktop )
-		{
-			// Visual transform
-			if( Input.GetButton( "Fire1" ) )
-			{
-				tmp_pos = btn.transform.localPosition;
-				tmp_pos.y = 0.0f;
-				btn.transform.localPosition = tmp_pos;
-			}
-
-			m_gm_dkoutline.SetActive( true );
-			m_gm_dkoutline.transform.localPosition = btn.transform.localPosition;
-			m_gm_dkoutline.transform.localRotation = btn.transform.localRotation;
-
-			m_outline_filter.sharedMesh = m_buttonmeshes[ typeid * 3 + 2 ];
-
-			// Actuation
-			if( Input.GetButtonDown( "Fire1" ) )
-			{
-				_htmenu_buttonpressed();
-				return true;
-			}
-		}
-		else // VR
-		{
-			// Button range
-			if( m_cursor.y < k_mGmButtonA && m_cursor.y > -0.1f )
-			{
-				// Update visual position
-				tmp_pos = btn.transform.localPosition;
-				tmp_pos.y = Mathf.Clamp( m_cursor.y, 0.0f, tmp_pos.y );
-				btn.transform.localPosition = tmp_pos;
-
-				m_auto_btnstate[ m_auto_id ] |= k_ButtonState_Pressing;
-
-				if( m_cursor.y <= 0.0f ) // Actuation
-				{
-					// Rising edge
-					if( m_auto_btnstate[ m_auto_id ] == k_ButtonState_Pressing )
-					{
-						m_auto_btnstate[ m_auto_id ] |= k_ButtonState_Triggered;
-
-						_htmenu_buttonpressed();
-						return true;
-					}
-				}
-			}
-		}
-	}
-
-	return false;
-}
-
-// Join lobby
-void _htjoinplayer( int id )
-{
-	#if HT8B_DEBUGGER
-	_frp( FRP_YES + "_htjoinplayer: " + id + FRP_END );
-	#endif
-
-	local_playerid = id;
-	local_teamid = ((uint)id & 0x2u) >> 1;
-	Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ id ] );
-
-	_htmenu_viewjoin();
-}
-
-// Join team locally
-void _htjointeam( int id )
-{
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + "_htjointeam: " + id + FRP_END );
-	#endif
-
-	// Leave routine
-	if( local_playerid >= 0 )
-	{
-		// Close lobby
-		if( local_playerid == 0 )
-		{
-			if( id == 0 )
-			{
-				#if HT8B_DEBUGGER
-				_frp( FRP_ERR + "( closing lobby )" + FRP_END );
-				#endif
-
-				sn_lobbyclosed = true;
-				local_playerid = -1;
-
-				_htmenuview();
-				Networking.SetOwner( Networking.LocalPlayer, this.gameObject );
-				_netpack_lossy();
-			}
-			else
-			{
-				#if HT8B_DEBUGGER
-				_frp( FRP_YES + "Starting game!" + FRP_END );
-				#endif
-
-				region_selected = false;
-				_tr_newgame();
-				return;
-			}
-		}
-		else
-		{
-			if( (int)local_teamid == id )
-			{
-				#if HT8B_DEBUGGER
-				_frp( FRP_WARN + "( leaving lobby )" + FRP_END );
-				#endif
-
-				// Set owner back to host
-				Networking.SetOwner( Networking.GetOwner( m_playerslot_owners[ 0 ] ), m_playerslot_owners[ local_playerid ] );
-
-				// Mark locally out of game
-				local_playerid = -1;
-			}
-			else
-			{
-				#if HT8B_DEBUGGER
-				_frp( FRP_LOW + "this button does nothing" + FRP_END );
-				#endif
-			}
-		}
-
-		_htmenu_viewjoin();
-		return;
-	}
-
-	// Create new lobby
-	if( sn_lobbyclosed )
-	{
-		#if HT8B_DEBUGGER
-		_frp( FRP_YES + "Creating lobby" + FRP_END );
-		#endif
-
-		// Assign other players to us to signify not joined
-		Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ 1 ] );
-		Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ 2 ] );
-		Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ 3 ] );
-		
-		sn_lobbyclosed = false;
-		
-		Networking.SetOwner( Networking.LocalPlayer, this.gameObject );
-		_netpack_lossy();
-
-		_htjoinplayer( 0 );
-		_htmenuview();
-		return;
-	}
-
-	VRCPlayerApi gameHost = Networking.GetOwner( m_playerslot_owners[ 0 ] );
-
-	// Check for open spot on team
-	// Team 1
-	if( id == 1 )
-	{
-		if( Networking.GetOwner( m_playerslot_owners[ 1 ] ).playerId == gameHost.playerId )
-		{
-			_htjoinplayer( 1 );
-		}
-		else if( sn_teams && (Networking.GetOwner( m_playerslot_owners[ 3 ] ).playerId == gameHost.playerId) )
-		{
-			_htjoinplayer( 3 );
-		}
-		else
-		{
-			#if HT8B_DEBUGGER
-			_frp( FRP_ERR + "no slot availible" + FRP_END );
-			#endif
-		}
-	} 
-
-	// Team 2
-	else if( sn_teams && (Networking.GetOwner( m_playerslot_owners[ 2 ] ).playerId == gameHost.playerId) )
-	{
-		_htjoinplayer( 2 );
-	}
-	else
-	{
-		#if HT8B_DEBUGGER
-		_frp( FRP_ERR + "no slot availible" + FRP_END );
-		#endif
-	}
-}
-
-void _htmenu_resetnetwork()
-{
-	sn_lobbyclosed = true;
-
-	if( Networking.GetOwner( this.gameObject ) == Networking.LocalPlayer )
-	{
-		Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ 0 ] );
-		Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ 1 ] );
-		Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ 2 ] );
-		Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ 3 ] );
-
-		_netpack_lossy();
-	}
-}
-
-// Find button target
-void _htmenu_trimin()
-{
-	m_auto_id = -1;
-
-	GameObject btn;
-
-	// Join / Leave buttons
-	m_current_x = k_mGmButtonW;
-	m_current_y = k_mGmButtonH;
-
-	if( sn_lobbyclosed )
-	{
-		if( _buttonpressed( m_newGameBtn, k_EButtonMesh_play ) )
-		{
-			_htjointeam( 0 );
-		}
-	}
-	else
-	{
-		for( int i = 0; i < m_join_buttons.Length; i ++ )
-		{
-			btn = m_join_buttons[ i ];
-
-			if( _buttonpressed( btn, k_EButtonMesh_join_0 + i ) )
-			{
-				_htjointeam( i );
-			}
-		}
-
-		if( local_playerid == 0 ) // Host only
-		{
-			// Gamemode buttons
-			m_current_x = k_mGmButtonW;
-			m_current_y = k_mGmButtonH;
-
-			for( int i = 0; i < m_gamemode_buttons.Length; i ++ )
-			{
-				btn = m_gamemode_buttons[ i ];
-		
-				if( _buttonpressed( btn, k_EButtonMesh_8ball + i ) )
-				{
-					sn_gamemode = (uint)i;
-					_htmenu_viewgm();
-					_netpack_lossy();
-				}
-			}
-
-			// Smol buttons
-			m_current_x = k_mSmolButtonR;
-			m_current_y = k_mSmolButtonR;
-
-			// Timelimit buttons
-			if( _buttonpressed( m_timebuttons[ 1 ], k_EButtonMesh_triangle ) )
-			{
-				if( sn_timer > 0 )
-				{
-					sn_timer --;
-
-					_htmenu_viewtimer();
-					_netpack_lossy();
-				}
-			}
-			if( _buttonpressed( m_timebuttons[ 0 ], k_EButtonMesh_triangle ) )
-			{
-				if( sn_timer < 2 )
-				{
-					sn_timer ++;
-
-					_htmenu_viewtimer();
-					_netpack_lossy();
-				}
-			}
-
-			// Teams enabled buttons
-			if( _buttonpressed( m_teambuttons[ 0 ], k_EButtonMesh_red ) )
-			{
-				sn_teams = false;
-				
-				// Kick players
-				Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ 2 ] );
-				Networking.SetOwner( Networking.LocalPlayer, m_playerslot_owners[ 3 ] );
-
-				_htmenu_viewteams();
-				_netpack_lossy();
-			}
-			if( _buttonpressed( m_teambuttons[ 1 ], k_EButtonMesh_green ) )
-			{
-				sn_teams = true;
-
-				_htmenu_viewteams();
-				_netpack_lossy();
-			}
-		}
-	}
-}
-
-VRC_Pickup.PickupHand _htmenu_hand = VRC_Pickup.PickupHand.None;
-
-void _htmenu_buttonpressed()
-{
-	aud_main.PlayOneShot( snd_btn );
-
-	if( _htmenu_hand != VRC_Pickup.PickupHand.None )
-	{
-		Networking.LocalPlayer.PlayHapticEventInHand( _htmenu_hand, 0.02f, 1.0f, 1.0f );
-	}
-}
-
-void _htmenu_begin()
-{
-	Vector3 tmp_pos;
-	GameObject btn;
-
-	for( int i = 0; i <= m_auto_id; i ++ )
-	{
-		if( m_auto_btnstate[ i ] == k_ButtonState_ShouldReset )
-		{
-			m_auto_btnstate[ i ] = k_ButtonState_None;
-		}
-
-		// Reset button Y position
-		btn = m_auto_btnobjs[ i ];
-		tmp_pos = btn.transform.localPosition;
-		tmp_pos.y = k_mGmButtonA;
-		btn.transform.localPosition = tmp_pos;
-
-		// Disables pressed so it can be re-set
-		m_auto_btnstate[ i ] &= k_ButtonState_FrameMask;
-	}
-}
-
-void _htmenu_enter()
-{
-	m_base.SetActive( true );
-	_htmenu_resetnetwork();
-
-	_htmenu_viewtimer();
-	_htmenu_viewteams();
-	_htmenu_viewgm();
-	_htmenu_viewjoin();
-	_htmenuview();
-}
-
-void _htmenu_exit()
-{
-	sn_lobbyclosed = true;
-	m_base.SetActive( false );
-}
-
-float next_refresh = 0.0f;
-
-void _htmenu_update()
-{
-	if (localplayer == null) // Removed the ifdef because rider didn't like it, just return if local player is null, means we're in editor.
-		return;
-	
-	m_desktop = !Networking.LocalPlayer.IsUserInVR();
-
-	if( Time.timeSinceLevelLoad > next_refresh )
-	{
-		_htmenu_viewjoin();
-		next_refresh = Time.timeSinceLevelLoad + 0.5f;
-	}
-
-	// Desktop: Project cursor onto plane
-	if( m_desktop )
-	{
-		m_gm_dkoutline.SetActive( false );
-
-		VRCPlayerApi.TrackingData hmd = localplayer.GetTrackingData( VRCPlayerApi.TrackingDataType.Head );
-		m_cursor = _plane_line_intersect( m_planenormal, m_planedist, hmd.position, hmd.position + (hmd.rotation * Vector3.forward) );
-
-		#if MENU_DEV
-		m_devcursor.transform.position = m_cursor;
-		#endif
-
-		// Localize m_cursor
-		m_cursor = m_base.transform.InverseTransformPoint( m_cursor );
-
-		_htmenu_hand = VRC_Pickup.PickupHand.None;
-		_htmenu_begin();
-		_htmenu_trimin();
-	}
-	else
-	{
-		#if MENU_DEV
-		m_devcursor.transform.position = localplayer.GetBonePosition( HumanBodyBones.RightIndexDistal );
-		#endif
-		
-		// Xiexe: Changed VR to use just the tracking data position, hopefully this feels alright.
-		_htmenu_begin(); 
-		_htmenu_hand = VRC_Pickup.PickupHand.Left;
-		VRCPlayerApi.TrackingData leftHand = localplayer.GetTrackingData(VRCPlayerApi.TrackingDataType.LeftHand);
-		m_cursor = m_base.transform.InverseTransformPoint( leftHand.position );
-		_htmenu_trimin();
-
-		_htmenu_hand = VRC_Pickup.PickupHand.Right;
-		VRCPlayerApi.TrackingData rightHand = localplayer.GetTrackingData(VRCPlayerApi.TrackingDataType.RightHand);
-		m_cursor = m_base.transform.InverseTransformPoint( rightHand.position );
-		_htmenu_trimin();
-	}
-
-	// Update visual stuff
-	m_TeamCover_current_s = Vector3.Lerp( m_TeamCover_current_s, m_TeamCover_target_s, Time.deltaTime * 5.0f );
-	m_TimeLimit_x_current = Vector3.Lerp( m_TimeLimit_x_current, m_TimeLimit_x_target, Time.deltaTime * 5.0f );
-	m_menuLoc_sw = Vector3.Lerp( m_menuLoc_sw, m_menuLoc_swt, Time.deltaTime * 5.0f );
-
-	// Stop sound
-	if( sound_spinning && Vector3.Distance( m_TimeLimit_x_current, m_TimeLimit_x_target ) < 0.01f )
-	{
-		sound_spinning = false;
-		aud_main.PlayOneShot( snd_spinstop );
-	}
-
-	m_TeamCover.transform.localScale = m_TeamCover_current_s;
-	m_TimeLimitDisp.transform.localPosition = m_TimeLimit_x_current;
-
-	// Menu locations scale swap
-	m_menuLoc_start.transform.localScale = m_menuLoc_sw;
-	m_menuLoc_main.transform.localScale = Vector3.one - m_menuLoc_sw;
-}
-
-#if UNITY_EDITOR
-void HTEditorUI()
-{
-	
-}
+#if UNITY_ANDROID
+#else
+    public Vector3 desktopTargetPos;             // Target for desktop aiming
 #endif
 
-#endregion
-
-
-float timeLast;
-float accum;
-// Copy current values to previous values, no memcpy here >:(
-void _sn_cpyprev()
-{
-	// Init _prv states
-	sn_turnid_prv = sn_turnid;
-	sn_open_prv = sn_open;
-	sn_gameover_prv = sn_gameover;
-	sn_gameid_prv = sn_gameid;
-
-	// Since 1.0.0
-	sn_gamemode_prv = sn_gamemode;
-	sn_timer_prv = sn_timer;
-	sn_teams_prv = sn_teams;
-	sn_lobbyclosed_prv = sn_lobbyclosed;
-
-	//sn_pocketed_prv = sn_pocketed;		this one needs to be independent 
-	//sn_simulating_prv = sn_simulating;
-	//sn_foul_prv = sn_foul;
-	//sn_playerxor_prv = sn_playerxor;
-	//sn_winnerid_prv = sn_winnerid;
-	//sn_permit_prv = sn_permit;
-}
-
-Vector3 dkCursor = new Vector3( 0.0f, 2.0f, 0.0f );
-Vector3 dkHitCursor = new Vector3( 0.0f, 0.0f, 0.0f );
-
-[SerializeField] GameObject dkCursorObj;
-[SerializeField] GameObject dkHitPos;
-[SerializeField] GameObject desktopBase;
-[SerializeField] GameObject desktopQuad;
-[SerializeField] GameObject[] dkStickBases;
-[SerializeField] GameObject dkOverlayPwr;
-[SerializeField] GameObject dk_E;
-
-const float k_DesktopCursorSpeed = 0.035f;
-bool dkShootingIn = false;
-bool dkSafeRemove = true;
-Vector3 dkShootVector;
-Vector3 dkSafeRemovePoint;
-float dkShootReference = 0.0f;
-float dkClampX = k_TABLE_WIDTH;
-float dkClampY = k_TABLE_HEIGHT;
-bool turnLocalLive = false;
-
-bool dkFrameIgnore = false;
-
-// Cue picked up local
-public void _ht_desktop_enter()
-{
-	dk_shootui = true;
-	dkFrameIgnore = true;
-	desktopBase.SetActive( true );
-
-	// Lock player in place
-	Networking.LocalPlayer.SetWalkSpeed( 0.0f );
-	Networking.LocalPlayer.SetRunSpeed( 0.0f );
-	Networking.LocalPlayer.SetStrafeSpeed( 0.0f );
-
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + "Entering desktop overlay" + FRP_END );
-	#endif
-}
-
-// Cue put down local
-public void _ht_desktop_cue_down()
-{
-	_ht_desktopui_exit();
-}
-
-void _ht_desktopui_exit()
-{
-	dk_shootui = false;
-	desktopBase.SetActive( false );
-
-	#if !HT_QUEST
-
-	gripControllers[ 0 ].dkPrimaryControl = true;
-	gripControllers[ 1 ].dkPrimaryControl = true;
-
-	Networking.LocalPlayer.SetWalkSpeed( 2.0f );
-	Networking.LocalPlayer.SetRunSpeed( 4.0f );
-	Networking.LocalPlayer.SetStrafeSpeed( 2.0f );
-
-	#endif
-}
-
-void _dk_AllowHit()
-{
-	turnLocalLive = true;
-
-	// Reset hit point
-	dkHitCursor = Vector3.zero;
-}
-
-void _dk_DenyHit()
-{
-	turnLocalLive = false;
-}
-
-float shootAmt = 0.0f;
-
-void _ht_desktopui_update()
-{
-	if( dkFrameIgnore )
-	{
-		dkFrameIgnore = false;
-		return;
-	}
-	
-	if( Input.GetKeyDown( KeyCode.E ) )
-	{
-		_ht_desktopui_exit();
-		return;
-	}
-
-	// Keep UI rendering
-	VRCPlayerApi.TrackingData hmd = localplayer.GetTrackingData( VRCPlayerApi.TrackingDataType.Head );
-	desktopQuad.transform.position = hmd.position + hmd.rotation * Vector3.forward;
-	dk_E.transform.position = desktopQuad.transform.position;
-
-	dkCursor.x = Mathf.Clamp
-	( 
-		dkCursor.x + Input.GetAxis("Mouse X") * k_DesktopCursorSpeed,
-		-dkClampX,
-		 dkClampX
-	);
-	dkCursor.z = Mathf.Clamp
-	( 
-		dkCursor.z + Input.GetAxis("Mouse Y") * k_DesktopCursorSpeed,
-		-dkClampY,
-		 dkClampY
-	);
-
-	if( turnLocalLive )
-	{
-		Vector3 ncursor = dkCursor;
-		ncursor.y = 0.0f;
-		Vector3 delta = ncursor - ball_CO[ 0 ];
-		GameObject cue = dkStickBases[ sn_turnid ];
-
-		if( Input.GetButton( "Fire1" ) )
-		{
-			if( !dkShootingIn )
-			{
-				dkShootingIn = true;
-
-				// Create shooting vector
-				dkShootVector = delta.normalized;
-
-				// Project reference start point
-				dkShootReference = Vector3.Dot( dkShootVector, ncursor );
-
-				// Create copy of cursor for later
-				dkSafeRemovePoint = dkCursor;
-
-				// Unlock cursor position from table
-				dkClampX = Mathf.Infinity;
-				dkClampY = Mathf.Infinity;
-			}
-
-			// Calculate shoot amount via projection
-			shootAmt = dkShootReference - Vector3.Dot( dkShootVector, ncursor );
-			dkSafeRemove = shootAmt < 0.0f;
-
-			shootAmt = Mathf.Clamp( shootAmt, 0.0f, 0.5f );
-
-			// Set delta back to dkShootVector
-			delta = dkShootVector;
-
-			// Disable cursor in shooting mode
-			dkCursorObj.SetActive( false );
-		}
-		else
-		{
-			// Trigger shot
-			if( dkShootingIn )
-			{
-				// Shot cancel
-				if( dkSafeRemove )
-				{
-
-				}
-				else // FIREEEEE 
-				{
-					// Fake hit ( kinda )
-					float vel = Mathf.Pow( shootAmt * 2.0f, 1.4f )*9.0f;
-				
-					ball_V[ 0 ] = dkShootVector * vel;
-
-					Vector3 r_1 = (RaySphere_output - ball_CO[ 0 ]) * k_BALL_1OR;
-					Vector3 p = dkShootVector.normalized * vel;
-					ball_W[ 0 ] = Vector3.Cross( r_1, p ) * -25.0f;
-
-					#if HT8B_DEBUGGER
-					_frp( FRP_WARN + "Angular velocity: " + ball_W[ 0 ].ToString() + ". Velocity: " + ball_V[ 0 ].ToString() + FRP_END );
-					#endif
-
-					cue.transform.localPosition = new Vector3( 2000.0f, 2000.0f, 2000.0f );
-					turnLocalLive = false;
-					_hit_general();
-				}
-
-				// Restore cursor position
-				dkCursor = dkSafeRemovePoint;
-				dkClampX = k_TABLE_WIDTH;
-				dkClampY = k_TABLE_HEIGHT;
-
-				// 1-frame override to fix rotation
-				delta = dkShootVector;
-			}
-
-			dkShootingIn = false;
-			shootAmt = 0.0f;
-			dkCursorObj.SetActive( true );
-		}
-
-		if( Input.GetKey( KeyCode.W ) )
-		{
-			dkHitCursor += Vector3.forward * Time.deltaTime;
-		}
-		if( Input.GetKey( KeyCode.S ) )
-		{
-			dkHitCursor += Vector3.back * Time.deltaTime;
-		}
-		if( Input.GetKey( KeyCode.A ) )
-		{
-			dkHitCursor += Vector3.left * Time.deltaTime;
-		}
-		if( Input.GetKey( KeyCode.D ) )
-		{
-			dkHitCursor += Vector3.right * Time.deltaTime;
-		}
-
-		// Clamp in circle
-		if( dkHitCursor.magnitude > 0.90f )
-		{
-			dkHitCursor = dkHitCursor.normalized * 0.9f;
-		}
-
-		dkHitPos.transform.localPosition = dkHitCursor;
-	
-		// Get angle
-		float ang = Mathf.Atan2( delta.x, delta.z );
-
-		// Create rotation
-		Quaternion xr = Quaternion.AngleAxis( 10.0f, Vector3.right );
-		Quaternion r = Quaternion.AngleAxis( ang * Mathf.Rad2Deg, Vector3.up );
-		
-		Vector3 worldHit = new Vector3(  dkHitCursor.x * k_BALL_PL_X, dkHitCursor.z * k_BALL_PL_X, -0.89f -shootAmt );
-
-		cue.transform.localRotation = r * xr;
-		cue.transform.position = this.transform.TransformPoint( ball_CO[ 0 ] + (r * xr * worldHit) );
-	}
-
-	dkCursorObj.transform.localPosition = dkCursor;
-	dkOverlayPwr.transform.localScale = new Vector3( 1.0f-(shootAmt*2.0f), 1.0f, 1.0f );
-}
-
-#region R_UNITY_MAGIC
-
-void _hit_general()
-{
-	// Make sure repositioner is turned off if the player decides he just
-	// wanted to hit it without putting it somewhere
-	isReposition = false;
-	markerObj.SetActive( false );
-	devhit.SetActive( false );
-	guideline.SetActive( false );
-
-	// Remove locks
-	_tr_endhit();
-	sn_permit = false;
-	sn_foul = false;	// In case did not drop foul marker
-
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + "Commiting changes" + FRP_END );
-	#endif
-
-	// Commit changes
-	sn_simulating = true;
-	sn_pocketed_prv = sn_pocketed;
-
-	// Make sure we definately are the network owner
-	Networking.SetOwner( Networking.LocalPlayer, this.gameObject );
-
-	_netpack( sn_turnid );
-	_netread();
-
-	sn_oursim = true;
-
-	float vol = Mathf.Clamp(ball_V[0].magnitude * 0.1f, 0f, 0.6f);
-	CueTipAudio.transform.position = cuetip.transform.position;
-	CueTipAudio.PlayOneShot(snd_hitball, vol);
-}
-
-private void Update()
-{
-	// Physics step accumulator routine
-	float time = Time.timeSinceLevelLoad;
-	float timeDelta = time - timeLast;
-
-	timeLast = time;
-
-	if( particle_alive )
-	{
-		_vis_floaty_eval();
-	}
-
-	if( dk_shootui )
-	{
-		_ht_desktopui_update();
-	}
-		
-	// Run sim only if things are moving
-	if( sn_simulating )
-	{
-		accum += timeDelta;
-
-		if ( accum > k_MAX_DELTA )
-		{
-			accum = k_MAX_DELTA;
-		}
-
-		while ( accum >= k_FIXED_TIME_STEP )
-		{
-			_phys_step();
-			accum -= k_FIXED_TIME_STEP;
-		}
-	}
-	else
-	{
-		// Control is in menu behaviour
-		if( sn_gameover )
-		{
-			_htmenu_update();
-			return;
-		}
-	}
-
-	// Update rendering objects positions
-	uint ball_bit = 0x1u;
-	for( int i = 0; i < 16; i ++ )
-	{
-		if( (ball_bit & sn_pocketed) == 0x0u )
-		{
-			balls_render[i].transform.localPosition = ball_CO[ i ];
-		}
-
-		ball_bit <<= 1;
-	}
-
-	cue_lpos = this.transform.InverseTransformPoint( cuetip.transform.position );
-	Vector3 lpos2 = cue_lpos;
-
-	// if shot is prepared for next hit
-	if( sn_permit )
-	{
-		bool isContact = false;
-
-		if( isReposition )
-		{
-			// Clamp position to table / kitchen
-			Vector3 temp = markerObj.transform.localPosition;
-			temp.x = Mathf.Clamp( temp.x, -k_TABLE_WIDTH, repoMaxX );
-			temp.z = Mathf.Clamp( temp.z, -k_TABLE_HEIGHT, k_TABLE_HEIGHT );
-			temp.y = 0.0f;
-			markerObj.transform.localPosition = temp;
-			markerObj.transform.localRotation = Quaternion.identity;
-
-			ball_CO[ 0 ] = temp;
-			balls_render[ 0 ].transform.localPosition = temp;
-
-			isContact = _cue_contacting();
-
-			if( isContact )
-			{
-				markerMaterial.SetColor( uniform_marker_colour, k_markerColourNO );
-			}
-			else
-			{
-				markerMaterial.SetColor( uniform_marker_colour, k_markerColourOK );
-			}
-		}
-
-		Vector3 cueball_pos = ball_CO[ 0 ];
-
-		if( sn_armed && !isContact )
-		{
-			float sweep_time_ball = Vector3.Dot( cueball_pos - cue_llpos, cue_vdir );
-
-			// Check for potential skips due to low frame rate
-			if( sweep_time_ball > 0.0f && sweep_time_ball < (cue_llpos - lpos2).magnitude )
-			{
-				lpos2 = cue_llpos + cue_vdir * sweep_time_ball;
-			}
-
-			// Hit condition is when cuetip is gone inside ball
-			if( (lpos2 - cueball_pos).sqrMagnitude < k_BALL_RSQR )
-			{
-				Vector3 horizontal_force = lpos2 - cue_llpos;
-				horizontal_force.y = 0.0f;
-
-				// Compute velocity delta
-				float vel = (horizontal_force.magnitude / Time.deltaTime) * 1.5f;
-
-				// Clamp velocity input to 20 m/s ( moderate break speed )
-				ball_V[ 0 ] = cue_shotdir * Mathf.Min( vel, 20.0f );
-
-				// Angular velocity: L=r(normalized)×p
-				Vector3 r = (RaySphere_output - cueball_pos) * k_BALL_1OR;
-				Vector3 p = cue_vdir * vel;
-				ball_W[ 0 ] = Vector3.Cross( r, p ) * -50.0f;
-
-				#if HT8B_DEBUGGER
-				_frp( FRP_WARN + "Angular velocity: " + ball_W[ 0 ].ToString() + ". Velocity: " + ball_V[ 0 ].ToString() + FRP_END );
-				#endif
-
-				_hit_general();
-			}
-		}
-		else
-		{
-			cue_vdir = this.transform.InverseTransformVector( cuetip.transform.forward );//new Vector2( cuetip.transform.forward.z, -cuetip.transform.forward.x ).normalized;
-
-			// Get where the cue will strike the ball
-			if( _phy_ray_sphere( lpos2, cue_vdir, cueball_pos ))
-			{
-				guideline.SetActive( true );
-				devhit.SetActive( true );
-				devhit.transform.localPosition = RaySphere_output;
-
-				cue_shotdir = cue_vdir;
-				cue_shotdir.y = 0.0f;
-
-				if( dk_shootui )
-				{
-				}
-				else
-				{
-					// Compute deflection in VR mode
-					Vector3 scuffdir = ( cueball_pos - RaySphere_output );
-					scuffdir.y = 0.0f;
-					cue_shotdir += scuffdir.normalized * 0.17f;
-				}
-
-				cue_fdir = Mathf.Atan2( cue_shotdir.z, cue_shotdir.x );
-
-				// Update the prediction line direction
-				guideline.transform.localPosition = ball_CO[ 0 ];
-				guideline.transform.localEulerAngles = new Vector3( 0.0f, -cue_fdir * Mathf.Rad2Deg, 0.0f );
-			}
-			else
-			{
-				devhit.SetActive( false );
-				guideline.SetActive( false );
-			}
-		}
-	}
-
-	cue_llpos = lpos2;
-
-	// Table outline colour
-	if( sn_gameover )
-	{
-		// Flashing if we won
-		#if !HT_QUEST
-		tableCurrentColour = tableSrcColour * (Mathf.Sin( Time.timeSinceLevelLoad * 3.0f) * 0.5f + 1.0f);
-		#endif
-		
-		infBaseTransform.transform.localPosition = new Vector3( 0.0f, Mathf.Sin( Time.timeSinceLevelLoad ) * 0.1f, 0.0f );
-		infBaseTransform.transform.Rotate( Vector3.up, 90.0f * Time.deltaTime );
-	}
-	else
-	{
-		#if !HT_QUEST
-		tableCurrentColour = Color.Lerp( tableCurrentColour, tableSrcColour, Time.deltaTime * 3.0f );
-		#else
+    Vector2 rayCircleOutput;
+    Vector3 raySphereOutput;
+
+    uint lastViewTimer = 0u;
+    bool isSoundSpinning = false;
+
+    uint gameModeTarget = 0u;
+    float gameModeMinHeight = Mathf.Infinity;
+
+    VRC_Pickup.PickupHand menuHand = VRC_Pickup.PickupHand.None;
+
+    float timeLast;
+    float accumulation;
+
+    private float nextRefresh = 0.0f;
+
+    float shootAmt = 0.0f;
+
+    int[] breaorder_8ball = { 9, 2, 10, 11, 1, 3, 4, 12, 5, 13, 14, 6, 15, 7, 8 };
+    int[] breaorder_9ball = { 2, 3, 4, 5, 9, 6, 7, 8, 1 };
+    int[] brearows_9ball = { 0, 1, 2, 1, 0 };
+
+    private void Start()
+    {
+        mainSrc = this.GetComponent<AudioSource>();
+
+        if (audioSourcePoolContainer != null) // Xiexe: Use a pool for audio instead of using the PlayClipAtPoint method because PlayClipAtPoint is buggy and VRC audio controls do not modify it.
+            ballPool = audioSourcePoolContainer.GetComponentsInChildren<AudioSource>();
+
+        InitializeMenu();
+        CopyCurrentValuesToPrevious();
+
+        cueRenderObjs[0].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, tableBlack);
+        cueRenderObjs[1].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, tableBlack);
+
+        guidelineMat.SetMatrix("_BaseTransform", this.transform.worldToLocalMatrix);
+
+        if (tableReflection != null)
+        {
+            tableReflection.gameObject.SetActive(true);
+            tableReflection.mode = ReflectionProbeMode.Realtime;
+            tableReflection.refreshMode = ReflectionProbeRefreshMode.ViaScripting;
+            tableReflection.timeSlicingMode = ReflectionProbeTimeSlicingMode.IndividualFaces;
+            tableReflection.RenderProbe();
+        }
+
+        // turn off guideline
+        DisableObjects();
+    }
+
+    private void Update()
+    {
+        // Physics step accumulator routine
+        float time = Time.timeSinceLevelLoad;
+        float timeDelta = time - timeLast;
+
+        timeLast = time;
+
+        if (isParticleAlive)
+        {
+            FloatyEval();
+        }
+
+        if (isDesktopShootUI)
+        {
+            UpdateDesktopUI();
+        }
+
+        // Run sim only if things are moving
+        if (gameIsSimulating)
+        {
+            accumulation += timeDelta;
+
+            if (accumulation > MAX_DELTA)
+            {
+                accumulation = MAX_DELTA;
+            }
+
+            while (accumulation >= FIXED_TIME_STEP)
+            {
+                AdvanceSimilationForAllBalls();
+                accumulation -= FIXED_TIME_STEP;
+            }
+        }
+        else
+        {
+            // Control is in menu behaviour
+            if (isGameOver)
+            {
+                UpdateMenu();
+                return;
+            }
+        }
+
+        // Update rendering objects positions
+        uint ball_bit = 0x1u;
+        for (int i = 0; i < 16; i++)
+        {
+            if ((ball_bit & ballPocketedState) == 0x0u)
+            {
+                ballsToRender[i].transform.localPosition = ball_CO[i];
+            }
+
+            ball_bit <<= 1;
+        }
+
+        cueLPos = this.transform.InverseTransformPoint(cueTip.transform.position);
+        Vector3 lpos2 = cueLPos;
+
+        // if shot is prepared for next hit
+        if (isPlayerAllowedToPlay)
+        {
+            bool isContact = false;
+
+            if (isReposition)
+            {
+                // Clamp position to table / kitchen
+                Vector3 temp = marker.transform.localPosition;
+                temp.x = Mathf.Clamp(temp.x, -TABLE_WIDTH, repoMaxX);
+                temp.z = Mathf.Clamp(temp.z, -TABLE_HEIGHT, TABLE_HEIGHT);
+                temp.y = 0.0f;
+                marker.transform.localPosition = temp;
+                marker.transform.localRotation = Quaternion.identity;
+
+                ball_CO[0] = temp;
+                ballsToRender[0].transform.localPosition = temp;
+
+                isContact = IsCueContacting();
+
+                if (isContact)
+                {
+                    markerMaterial.SetColor(uniformMarkerColour, markerNotOK);
+                }
+                else
+                {
+                    markerMaterial.SetColor(uniformMarkerColour, markerOK);
+                }
+            }
+
+            Vector3 cueball_pos = ball_CO[0];
+
+            if (isArmed && !isContact)
+            {
+                float sweep_time_ball = Vector3.Dot(cueball_pos - cueLLPos, cueVDir);
+
+                // Check for potential skips due to low frame rate
+                if (sweep_time_ball > 0.0f && sweep_time_ball < (cueLLPos - lpos2).magnitude)
+                {
+                    lpos2 = cueLLPos + cueVDir * sweep_time_ball;
+                }
+
+                // Hit condition is when cuetip is gone inside ball
+                if ((lpos2 - cueball_pos).sqrMagnitude < BALL_RSQR)
+                {
+                    Vector3 horizontal_force = lpos2 - cueLLPos;
+                    horizontal_force.y = 0.0f;
+
+                    // Compute velocity delta
+                    float vel = (horizontal_force.magnitude / Time.deltaTime) * 1.5f;
+
+                    // Clamp velocity input to 20 m/s ( moderate break speed )
+                    ball_V[0] = cueShotDir * Mathf.Min(vel, 20.0f);
+
+                    // Angular velocity: L=r(normalized)×p
+                    Vector3 r = (raySphereOutput - cueball_pos) * BALL_1OR;
+                    Vector3 p = cueVDir * vel;
+                    ball_W[0] = Vector3.Cross(r, p) * -50.0f;
+
+#if HT8B_DEBUGGER
+                    _frp(FRP_WARN + "Angular velocity: " + ball_W[0].ToString() + ". Velocity: " + ball_V[0].ToString() + FRP_END);
+#endif
+
+                    HitGenerically();
+                }
+            }
+            else
+            {
+                cueVDir = this.transform.InverseTransformVector(cueTip.transform.forward);//new Vector2( cuetip.transform.forward.z, -cuetip.transform.forward.x ).normalized;
+
+                // Get where the cue will strike the ball
+                if (IsIntersectignWithSphere(lpos2, cueVDir, cueball_pos))
+                {
+                    guideline.SetActive(true);
+                    devhit.SetActive(true);
+                    devhit.transform.localPosition = raySphereOutput;
+
+                    cueShotDir = cueVDir;
+                    cueShotDir.y = 0.0f;
+
+                    if (isDesktopShootUI)
+                    {
+                    }
+                    else
+                    {
+                        // Compute deflection in VR mode
+                        Vector3 scuffdir = (cueball_pos - raySphereOutput);
+                        scuffdir.y = 0.0f;
+                        cueShotDir += scuffdir.normalized * 0.17f;
+                    }
+
+                    cueFDir = Mathf.Atan2(cueShotDir.z, cueShotDir.x);
+
+                    // Update the prediction line direction
+                    guideline.transform.localPosition = ball_CO[0];
+                    guideline.transform.localEulerAngles = new Vector3(0.0f, -cueFDir * Mathf.Rad2Deg, 0.0f);
+                }
+                else
+                {
+                    devhit.SetActive(false);
+                    guideline.SetActive(false);
+                }
+            }
+        }
+
+        cueLLPos = lpos2;
+
+        // Table outline colour
+        if (isGameOver)
+        {
+            // Flashing if we won
+#if !UNITY_ANDROID
+            tableCurrentColour = tableSrcColour * (Mathf.Sin(Time.timeSinceLevelLoad * 3.0f) * 0.5f + 1.0f);
+#endif
+
+            infBaseTransform.transform.localPosition = new Vector3(0.0f, Mathf.Sin(Time.timeSinceLevelLoad) * 0.1f, 0.0f);
+            infBaseTransform.transform.Rotate(Vector3.up, 90.0f * Time.deltaTime);
+        }
+        else
+        {
+#if !UNITY_ANDROID
+            tableCurrentColour = Color.Lerp(tableCurrentColour, tableSrcColour, Time.deltaTime * 3.0f);
+#else
 
 		// Run uniform updates at a slower rate on android (/8)
 		ANDROID_UNIFORM_CLOCK ++;
 
-		if( ANDROID_UNIFORM_CLOCK >= ANDROID_CLOCK_DIVIDER )
+		if( ANDROID_UNIFORM_CLOCK >= ANDROID_CLOCDIVIDER )
 		{
 			tableCurrentColour = Color.Lerp( tableCurrentColour, tableSrcColour, Time.deltaTime * 24.0f );
 			tableMaterial.SetColor( uniform_tablecolour, tableCurrentColour );
@@ -3306,832 +741,3096 @@ private void Update()
 			ANDROID_UNIFORM_CLOCK = 0x00u;
 		}
 
-		#endif
-	}
+#endif
+        }
 
-	float time_percentage;
-	if( timer_running )
-	{
-		float timeleft = timer_end - Time.timeSinceLevelLoad;
+        float time_percentage;
+        if (isTimerRunning)
+        {
+            float timeleft = timerEnd - Time.timeSinceLevelLoad;
 
-		if( timeleft < 0.0f )
-		{
-			_onlocal_timer_end();
-			time_percentage = 0.0f;
-		}
-		else
-		{
-			time_percentage = 1.0f - (timeleft * timer_recip);
-		}
-	}
-	else
-	{
-		time_percentage = 0.0f;
-	}
+            if (timeleft < 0.0f)
+            {
+                OnLocalTimerEnd();
+                time_percentage = 0.0f;
+            }
+            else
+            {
+                time_percentage = 1.0f - (timeleft * timerRecp);
+            }
+        }
+        else
+        {
+            time_percentage = 0.0f;
+        }
 
-#if !HT_QUEST
-	tableMaterial.SetColor( uniform_tablecolour, 
-		new Color( tableCurrentColour.r, tableCurrentColour.g, tableCurrentColour.b, time_percentage ) );
+#if !UNITY_ANDROID
+        tableMaterial.SetColor(uniformTableColour,
+            new Color(tableCurrentColour.r, tableCurrentColour.g, tableCurrentColour.b, time_percentage));
 #endif
 
-	// Intro animation
-	if( introAminTimer > 0.0f )
-	{
-		introAminTimer -= Time.deltaTime;
-
-		Vector3 temp;
-		float atime;
-		float aitime;
-
-		if( introAminTimer < 0.0f )
-			introAminTimer = 0.0f;
-
-		// Cueball drops late
-		temp = balls_render[0].transform.localPosition;
-		atime = Mathf.Clamp(introAminTimer - 0.33f, 0.0f, 1.0f); 
-		aitime = (1.0f - atime);
-		temp.y = Mathf.Abs(Mathf.Cos(atime * 6.29f)) * atime * 0.5f;
-		balls_render[0].transform.localPosition = temp;
-		balls_render[0].transform.localScale = new Vector3(aitime, aitime, aitime);
-
-		for ( int i = 1; i < 16; i ++ )
-		{
-			temp = balls_render[i].transform.localPosition;
-			atime = Mathf.Clamp(introAminTimer - 0.84f - (float)i * 0.03f, 0.0f, 1.0f);
-			aitime = (1.0f - atime);
-
-			temp.y = Mathf.Abs( Mathf.Cos( atime * 6.29f ) ) * atime * 0.5f;
-			balls_render[i].transform.localPosition = temp;
-			balls_render[i].transform.localScale = new Vector3(aitime, aitime, aitime);
-		}
-	}
-}
-
-private void Start()
-{
-	aud_main = this.GetComponent<AudioSource>();
-	
-	if(AudioSourcePoolContainer != null) // Xiexe: Use a pool for audio instead of using the PlayClipAtPoint method because PlayClipAtPoint is buggy and VRC audio controls do not modify it.
-		ball_AudioPool = AudioSourcePoolContainer.GetComponentsInChildren<AudioSource>();
-	
-	_htmenu_init();
-	_sn_cpyprev();
-	
-	cueRenderObjs[ 0 ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, k_tableColourBlack );
-	cueRenderObjs[ 1 ].GetComponent< MeshRenderer >().sharedMaterial.SetColor( uniform_cue_colour, k_tableColourBlack );
-
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + "Starting" + FRP_END );
-	#endif
-
-	#if COMPILE_FUNC_TESTS
-	_setup_break();
-	#endif
-	
-	guidelineMat.SetMatrix( "_BaseTransform", this.transform.worldToLocalMatrix );
-
-	if (Table_Probe != null)
-	{
-		Table_Probe.gameObject.SetActive(true);
-		Table_Probe.mode = ReflectionProbeMode.Realtime;
-		Table_Probe.refreshMode = ReflectionProbeRefreshMode.ViaScripting;
-		Table_Probe.timeSlicingMode = ReflectionProbeTimeSlicingMode.IndividualFaces;
-		Table_Probe.RenderProbe();
-	}
-
-	// turn off guideline
-	_vis_disableobjects();
-}
-
-#endregion
-
-int[] break_order_8ball = { 9, 2, 10, 11, 1, 3, 4, 12, 5, 13, 14, 6, 15, 7, 8 };
-int[] break_order_9ball = { 2, 3, 4, 5, 9, 6, 7, 8, 1 };
-int[] break_rows_9ball = { 0, 1, 2, 1, 0 }; 
-
-// Resets local game state to defined state
-// TODO: Merge this with NewGame()
-public void _setup_break()
-{
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + "SetupBreak()" + FRP_END );
-	#endif
-
-	sn_simulating = false;
-	sn_open = true;
-	sn_gameover = false;
-	sn_playerxor = 0;
-	sn_winnerid = 0;
-
-	// Cue ball
-	ball_CO[ 0 ] = new Vector3( -k_SPOT_POSITION_X, 0.0f, 0.0f );
-	ball_V[ 0 ] = Vector3.zero;
-
-	// Start at spot
-
-	if( gm_is_1 ) // 9 ball
-	{
-		sn_pocketed = 0xFC00u;
-
-		for( int i = 0, k = 0; i < 5; i ++ )
-		{
-			int rown = break_rows_9ball[ i ];
-			for( int j = 0; j <= rown; j ++ )
-			{
-				ball_CO[ break_order_9ball[ k ++ ] ] = new Vector3
-				( 
-					k_SPOT_POSITION_X + (float)i * k_BALL_PL_Y + UnityEngine.Random.Range(-k_RANDOMIZE_F, k_RANDOMIZE_F), 
-					0.0f, 
-					(float)(-rown + j * 2) * k_BALL_PL_X + UnityEngine.Random.Range(-k_RANDOMIZE_F, k_RANDOMIZE_F)
-				);
-
-				ball_V[ k ] = Vector3.zero;
-				ball_W[ k ] = Vector3.zero;
-			}
-		}
-	}
-	else if( gm_is_2 ) // 4 ball
-	{
-		sn_pocketed = 0xFDF2u;
-
-		ball_CO[ 0 ] = new Vector3( -k_SPOT_CAROM_X, 0.0f, 0.0f );
-		ball_CO[ 9 ] = new Vector3(  k_SPOT_CAROM_X, 0.0f, 0.0f );
-		ball_CO[ 2 ] = new Vector3(  k_SPOT_POSITION_X, 0.0f, 0.0f );
-		ball_CO[ 3 ] = new Vector3( -k_SPOT_POSITION_X, 0.0f, 0.0f );
-
-		ball_V[ 0 ] = Vector3.zero;
-		ball_V[ 9 ] = Vector3.zero;
-		ball_V[ 2 ] = Vector3.zero;
-		ball_V[ 3 ] = Vector3.zero;
-
-		ball_W[ 0 ] = Vector3.zero;
-		ball_W[ 9 ] = Vector3.zero;
-		ball_W[ 2 ] = Vector3.zero;
-		ball_W[ 3 ] = Vector3.zero;
-	}
-	else // Normal 8 ball modes
-	{
-		sn_pocketed = 0x00u;
-
-		for( int i = 0, k = 0; i < 5; i ++ )
-		{
-			for( int j = 0; j <= i; j ++ )
-			{
-				ball_CO[ break_order_8ball[ k ++ ] ] = new Vector3
-				( 
-					k_SPOT_POSITION_X + (float)i * k_BALL_PL_Y + UnityEngine.Random.Range(-k_RANDOMIZE_F, k_RANDOMIZE_F), 
-					0.0f, 
-					(float)(-i + j * 2) * k_BALL_PL_X + UnityEngine.Random.Range(-k_RANDOMIZE_F, k_RANDOMIZE_F)
-				);
-
-				ball_V[ k ] = Vector3.zero;
-				ball_W[ k ] = Vector3.zero;
-			}
-		}
-	}
-
-	sn_pocketed_prv = sn_pocketed;
-}
-
-
-#region R_INTERFACING
-
-// Purpose: 
-//  Public methods which should are called from other behaviours
-
-// Player select 4 ball mode Japanese
-public void _tr_yotsudama()
-{
-	fb_jp = true;
-	fb_kr = false;
-	region_selected = true;
-	select4b.SetActive( false );
-
-	_tr_newgame();
-}
-
-public void _tr_sagu()
-{
-	fb_jp = false;
-	fb_kr = true;
-	region_selected = true;
-	select4b.SetActive( false );
-
-	_tr_newgame();
-}
-
-// Player is holding input trigger
-public void _tr_starthit()
-{
-	// lock aim variables
-	bool isOurTurn = ((local_playerid >= 0) && (local_teamid == sn_turnid)) || gm_practice;
-
-	if( isOurTurn )
-	{
-		sn_armed = true;
-
-		#if !HT_QUEST
-		guidelineMat.SetColor( "_Colour", k_aimColour_locked );
-		#endif
-	}
-}
-
-// Player stopped holding input trigger
-public void _tr_endhit()
-{
-	sn_armed = false;
-
-	#if !HT_QUEST
-	guidelineMat.SetColor( "_Colour", k_aimColour_aim );
-	#endif 
-}
-
-// Player was moving cueball, place it down
-public void _tr_placeball()
-{
-	if( !_cue_contacting() )
-	{
-		isReposition = false;
-		markerObj.SetActive( false );
-
-		sn_permit = true;
-		sn_foul = false;
-
-		Networking.SetOwner( Networking.LocalPlayer, this.gameObject );
-
-		// Save out position to remote clients
-		_netpack( sn_turnid );
-		_netread();
-	}
-}
-
-// Initialize new match as the host
-public void _tr_newgame()
-{
-	// Check if game in progress
-	if( sn_gameover )
-	{
-		#if HT8B_DEBUGGER
-		_frp( FRP_YES + "Starting new game" + FRP_END );
-		#endif
-
-		// Get gamestate rolling
-		sn_gameid ++;
-		sn_permit = true;
-
-		_onlocal_newgame();
-
-		sn_turnid = 0;
-		sn_turnid_prv = 0;
-		_onlocal_turnchange();
-
-		// Following is overrides of NewGameLocal, for game STARTER only
-		_setup_break();
-		_vis_apply_tablecolour(0);
-
-		Networking.SetOwner( Networking.LocalPlayer, this.gameObject );
-		_netpack( 0 );
-		_netread();
-
-		// Override allow repositioning within kitchen
-		// Local effector
-		isReposition = true;
-		repoMaxX = -k_SPOT_POSITION_X;
-		markerObj.transform.localPosition = ball_CO[ 0 ];
-		markerObj.SetActive( true );
-
-		if( !region_selected )
-		{
-			if( sn_gamemode == 2u )
-			{
-				select4b.SetActive( true );
-				return;
-			}
-		}
-	}
-	else
-	{
-		// Should not be hit since v1.0.0
-		#if HT8B_DEBUGGER
-		_frp( FRP_ERR + "game in progress" + FRP_END );
-		#endif
-	}
-}
-
-// Completely reset ht8b state
-public void _tr_force_end()
-{
-	// Limit reset to totem owners ownly, this will always be someone in the room
-	// but it may not be obvious to players who has the ownership. So a info text
-	// is added above the reset button telling them who can reset if they dont have it
-	// this is simply to prevent trolls running in and force resetting at random
-
-	if( Networking.LocalPlayer == Networking.GetOwner( playerTotems[0] ) ||
-		Networking.LocalPlayer == Networking.GetOwner( playerTotems[1] )
-		|| sn_gameover )
-	{
-		#if HT8B_DEBUGGER
-		_frp( FRP_WARN + "Ending game early" + FRP_END );
-		#endif
-
-		sn_gameover = true;
-		sn_permit = false;
-		sn_simulating = false;
-
-		// For good measure in case other clients trigger an event whilst owner
-		sn_packetid += 2;
-
-		Networking.SetOwner( Networking.LocalPlayer, this.gameObject );
-		_netpack( sn_turnid );
-		_netread();
-
-		_onlocal_gameover();
-
-		infReset.text = "Reset" ;
-	}
-	else
-	{
-		// TODO: Make this a panel
-		#if HT8B_DEBUGGER
-		_frp( FRP_ERR + "Reset is availible to: " + Networking.GetOwner( playerTotems[0] ).displayName + " and " + Networking.GetOwner( playerTotems[1] ).displayName + FRP_END );
-		#endif
-
-		infReset.text = "Only:\n" + Networking.GetOwner( playerTotems[0] ).displayName + " and " + Networking.GetOwner( playerTotems[1] ).displayName + "\ncan reset";
-	}
-}
-
-#endregion
-
-#region R_NETWORK
-
-const float I16_MAXf = 32767.0f;
-
-void _encode_u16( int pos, ushort v ) 
-{
-	net_data[ pos ] = (byte)(v & 0xff);
-	net_data[ pos + 1 ] = (byte)(((uint)v >> 8) & 0xff);
-}
-
-ushort _decode_u16( int pos ) 
-{
-	return (ushort)(net_data[pos] | (((uint)net_data[pos+1]) << 8));
-}
-
-// 4 char string from Vector2. Encodes floats in: [ -range, range ] to 0-65535
-void _encode_vec3( int pos, Vector3 vec, float range )
-{
-	_encode_u16( pos, (ushort)((vec.x / range) * I16_MAXf + I16_MAXf ) );
-	_encode_u16( pos + 2, (ushort)((vec.z / range) * I16_MAXf + I16_MAXf ) );
-}
-
-// 6 char string from Vector3. Encodes floats in: [ -range, range ] to 0-65535
-void _encode_vec3_full( int pos, Vector3 vec, float range )
-{
-	_encode_u16( pos, (ushort)((Mathf.Clamp( vec.x, -range, range ) / range) * I16_MAXf + I16_MAXf ) );
-	_encode_u16( pos + 2, (ushort)((Mathf.Clamp( vec.y, -range, range ) / range) * I16_MAXf + I16_MAXf ) );
-	_encode_u16( pos + 4, (ushort)((Mathf.Clamp( vec.z, -range, range ) / range) * I16_MAXf + I16_MAXf ) );
-}
-
-// Decode 4 chars at index to Vector3 (x,z). Decodes from 0-65535 to [ -range, range ]
-Vector3 _decode_vec3( int start, float range )
-{
-	ushort _x = _decode_u16( start );
-	ushort _y = _decode_u16( start + 2 );
-
-	float x = ((_x - I16_MAXf) / I16_MAXf) * range;
-	float y = ((_y - I16_MAXf) / I16_MAXf) * range;
-		
-	return new Vector3( x, 0.0f, y );
-}
-
-// Decode 6 chars at index to Vector3. Decodes from 0-65535 to [ -range, range ]
-Vector3 _decode_vec3_full( int start, float range )
-{
-	ushort _x = _decode_u16( start );
-	ushort _y = _decode_u16( start + 2 );
-	ushort _z = _decode_u16( start + 4 );
-
-	float x = ((_x - I16_MAXf) / I16_MAXf) * range;
-	float y = ((_y - I16_MAXf) / I16_MAXf) * range;
-	float z = ((_z - I16_MAXf) / I16_MAXf) * range;
-		
-	return new Vector3( x, y, z );
-} 
-
-public void _netpack_lossy()
-{
-	if( !sn_gameover )
-	{
-		#if HT8B_DEBUGGER
-		_frp( FRP_ERR + "Critical error: gameover was false when trying to _netpack_lossy()" + FRP_END );
-		#endif
-		return;
-	}
-
-	// Game state
-	uint flags = 0x20u;						// bit #
-
-	// Since v1.0.0
-	flags |= sn_gamemode << 8;				// 8  - 3 bits
-	flags |= sn_timer << 13;				// 13 - 2 bits
-	if( sn_teams ) flags |= 0x8000u;		// 15 - 1 bit
-	if( sn_lobbyclosed ) flags |= 0x800u;
-
-	_encode_u16( 0x4C, (ushort)flags );
-
-	sn_packetid = (ushort)(sn_packetid + 1u);
-	_encode_u16( 0x4E, (ushort)(sn_packetid) );
-	_encode_u16( 0x50, sn_gameid );
-
-	netstr = Convert.ToBase64String( net_data, Base64FormattingOptions.None );
-}
-
-// Encode all data of game state into netstr
-public void _netpack( uint _turnid )
-{
-	if( local_playerid < 0 )
-	{
-		#if HT8B_DEBUGGER
-		_frp( FRP_ERR + "Critical error: local_playerid was less than 0 when trying to NetPack()" + FRP_END );
-		#endif
-		return;
-	}
-
-	// Garuntee array size by reallocating.. because c#
-	net_data = new byte[0x52];
-
-	for ( int i = 0; i < 16; i ++ )
-	{
-		_encode_vec3( i * 4, ball_CO[ i ], 2.5f );
-	}
-
-	// Cue ball velocity & angular velocity last
-	_encode_vec3( 0x40, ball_V[ 0 ], 50.0f );
-	_encode_vec3_full( 0x44, ball_W[ 0 ], 500.0f );
-
-	if( gm_is_2 )
-	{
-		// Encode player scores into gmspec
-		sn_gmspec  = (ushort)(((uint)fb_scores[ 0 ]) & 0x0fu);
-		sn_gmspec |= (ushort)((((uint)fb_scores[ 1 ]) & 0x0fu) << 4);
-		if( fb_kr ) sn_gmspec |= (ushort)0x100u;
-
-		// 4 ball specifc ( no pocket info )
-		_encode_u16( 0x4A, sn_gmspec );
-	}
-	else
-	{
-		// Encode pocketed imformation
-		_encode_u16( 0x4A, (ushort)(sn_pocketed & 0x0000FFFFu) );
-	}
-
-	// Game state
-	uint flags = 0x0U;						// bit #
-	if( sn_simulating ) flags |= 0x1U;	// 0
-	flags |= _turnid << 1;					// 1
-	if( sn_foul ) flags |= 0x4U;			// 2
-	if( sn_open ) flags |= 0x8U;			// 3
-	flags |= sn_playerxor << 4;			// 4
-	if( sn_gameover ) flags |= 0x20u;	// 5
-	flags |= sn_winnerid << 6;				// 6
-	if( sn_permit ) flags |= 0x80U;		// 7
-
-	if( sn_lobbyclosed ) flags |= 0x800u;
-
-	// Since v1.0.0
-	flags |= sn_gamemode << 8;				// 8  - 3 bits
-	flags |= sn_timer << 13;				// 13 - 2 bits
-	if( sn_teams ) flags |= 0x8000u;		// 15 - 1 bit
-
-	_encode_u16( 0x4C, (ushort)flags );
-
-	// Player ID msb gets added to referee any discrepencies between clients
-	// Higher order players get priority because it will be less common
-	// to play 2v2, so we can save most packet id's for normal 1v1
-	uint msb_playerid = ((uint)local_playerid & 0x2u) >> 1;
-
-	_encode_u16( 0x4E, (ushort)(sn_packetid + 1u + msb_playerid) );
-	_encode_u16( 0x50, sn_gameid );
-
-	netstr = Convert.ToBase64String( net_data, Base64FormattingOptions.None );
-
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + "NetPack()" + FRP_END );
-	#endif
-}
-
-// Decode networking string
-// TODO: Clean up this function
-public void _netread()
-{
-	// CHECK ERROR ===================================================================================================
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + "incoming base64: " + netstr + FRP_END );
-	#endif
-
-	byte[] in_data = Convert.FromBase64String( netstr );
-	if( in_data.Length < 0x52 ) {
-			
-		#if HT8B_DEBUGGER
-		_frp( FRP_WARN + "Sync string too short for decode, skipping\n" + FRP_END );
-		#endif
-
-		return; 
-	}
-
-	net_data = in_data;
-
-	#if HT8B_DEBUGGER
-	_frp( FRP_LOW + _netstr_hex() + FRP_END );
-	#endif
-
-	// Throw out updates that are possible errournous
-	ushort nextid = _decode_u16( 0x4E );
-	if( nextid <= sn_packetid )
-	{
-		#if HT8B_DEBUGGER
-		_frp( FRP_WARN + "Packet ID was old ( " + nextid + " <= " + sn_packetid + " ). Throwing out update" + FRP_END );
-		#endif
-
-		return;
-	}
-	sn_packetid = nextid;
-
-	// MAIN DECODE ===================================================================================================
-	_sn_cpyprev();
-
-	// Pocketed information
-	// Ball positions, reset velocity
-	
-	for( int i = 0; i < 16; i ++ )
-	{
-		ball_V[ i ] = Vector3.zero;
-		ball_W[ i ] = Vector3.zero;
-		ball_CO[ i ] = _decode_vec3( i * 4, 2.5f );
-	}
-
-	ball_V[ 0 ] = _decode_vec3( 0x40, 50.0f );
-	ball_W[ 0 ] = _decode_vec3_full( 0x44, 500.0f );
-
-	sn_pocketed = _decode_u16( 0x4A );
-
-	uint gamestate = _decode_u16( 0x4C );
-	sn_simulating = (gamestate & 0x1U) == 0x1U;
-	sn_turnid = (gamestate & 0x2U) >> 1;
-	sn_foul = (gamestate & 0x4U) == 0x4U;
-	sn_open = (gamestate & 0x8U) == 0x8U;
-	sn_playerxor = (gamestate & 0x10U) >> 4;
-	sn_gameover = (gamestate & 0x20U) == 0x20U;
-	sn_winnerid = (gamestate & 0x40U) >> 6;
-	sn_permit = (gamestate & 0x80U) == 0x80U;	
-	sn_lobbyclosed = (gamestate & 0x800u) == 0x800u;
-
-	// Since v1.0.0
-	sn_gamemode = (gamestate & 0x700u) >> 8;			// 3 bits
-	sn_timer = (gamestate & 0x6000u) >>  13;			// 2 bits
-	sn_teams = (gamestate & 0x8000u) == 0x8000u;		//
-
-	// TODO: allocate more bits to packet ID, less to game ID
-	sn_gameid = _decode_u16( 0x50 );
-
-	// Events ==========================================================================================================
-
-	if( sn_gameid > sn_gameid_prv && !sn_gameover )
-	{
-		// EV: 1
-		#if HT8B_DEBUGGER
-		_frp( FRP_YES + " .EV: 1 (sn_gameid > sn_gameid_prv) -> NewGame" + FRP_END );
-		#endif
-
-		_onlocal_newgame();
-	}
-
-	// Check if turn was transferred
-	if( sn_turnid != sn_turnid_prv )
-	{
-		// EV: 2
-		#if HT8B_DEBUGGER
-		_frp( FRP_YES + " .EV: 2 (sn_turnid != sn_turnid_prv) -> NewTurn" + FRP_END );
-		#endif
-
-		_onlocal_turnchange();
-	}
-
-	// Table switches to closed
-	if( sn_open_prv && !sn_open )
-	{
-		// EV: 3
-		#if HT8B_DEBUGGER
-		_frp( FRP_YES + " .EV: 3 (sn_open_prv && !sn_open) -> DisplaySet" + FRP_END );
-		#endif
-
-		_onlocal_tableclosed();
-	}
-
-	// Check if game is over
-	if(!sn_gameover_prv && sn_gameover)
-	{
-		// EV: 4
-		#if HT8B_DEBUGGER
-		_frp( FRP_YES + " .EV: 4 (!sn_gameover_prv && sn_gamemover) -> Gameover" + FRP_END );
-		#endif
-
-		_onlocal_gameover();
-		return;
-	}
-
-	if( sn_gameover )
-	{
-		_htmenu_viewtimer();
-		_htmenu_viewteams();
-		_htmenu_viewgm();
-		_htmenu_viewjoin();
-		_htmenuview();
-		return;
-	}
-
-	// Effects colliders need to be turned off when not simulating
-	// to improve pickups being glitchy
-	if( sn_simulating )
-	{
-		fxColliderBase.SetActive( true );
-	}
-	else
-	{
-		fxColliderBase.SetActive( false );
-	}
-
-	if( gm_is_2 )
-	{
-		sn_gmspec = _decode_u16( 0x4A );
-		fb_scores[ 0 ] = (int)(sn_gmspec & 0x0fu);
-		fb_scores[ 1 ] = (int)((sn_gmspec & 0xf0u) >> 4);
-
-		fb_kr = (sn_gmspec & 0x100u) == 0x100u;
-		fb_jp = !fb_kr;
-
-		sn_pocketed = 0xFDF2u;
-	}
-
-	// Check this every read
-	// Its basically 'turn start' event
-	if( sn_permit )
-	{
-		bool isOurTurn = ((local_playerid >= 0) && (local_teamid == sn_turnid)) || gm_practice;
-		
-		// Check if teammate placed the positioner
-		if( !sn_foul )
-		{
-			#if HT8B_DEBUGGER
-			_frp( FRP_YES + " .EV: 3 (!sn_foul && sn_foul_prv && sn_permit) -> Marker placed" + FRP_END );
-			#endif
-
-			isReposition = false;
-			markerObj.SetActive( false );
-		}
-
-		#if !HT_QUEST
-		if( isOurTurn )
-		{
-			// Update for desktop
-			_dk_AllowHit();	
-		}
-		else
-		{
-			_dk_DenyHit();
-		}
-		#endif
-
-		if( gm_is_1 )
-		{
-			int target = _lowest_ball( sn_pocketed );
-
-			marker9ball.SetActive( true );
-			marker9ball.transform.localPosition = ball_CO[ target ];
-		}
-
-		#if !HT_QUEST
-		_vis_rackballs();
-		#endif
-
-		if( sn_timer > 0 && !timer_running )
-		{
-			_timer_reset();
-		}
-	}
-	else
-	{
-		marker9ball.SetActive( false );
-		timer_running = false;
-		fb_madepoint = false;
-		fb_madefoul = false;
-		sn_firsthit = 0;
-		sn_secondhit = 0;
-		sn_thirdhit = 0;
-		
-		// These dissapeared from v1.0.0 for some reason
-		markerObj.SetActive( false );
-		devhit.SetActive( false );
-		guideline.SetActive( false );
-	}
-
-	_onlocal_updatescorecard();
-}
-
-string _netstr_hex()
-{
-	string str = "";
-
-	for( int i = 0; i < net_data.Length; i += 2 )
-	{
-		ushort v = _decode_u16( i );
-		str += v.ToString("X4");
-	}
-
-	return str;
-}
-
-// Wait for updates to the synced netstr
-public override void OnDeserialization()
-{
-	if( !string.Equals( netstr, netstr_prv ) )
-	{
-		#if HT8B_DEBUGGER
-		_frp( FRP_LOW + "OnDeserialization() :: netstr update" + FRP_END );
-		#endif
-
-		netstr_prv = netstr;
-
-		// Check if local simulation is in progress, the event will fire off later when physics
-		// are settled by the client
-		if( sn_simulating )
-		{
-			#if HT8B_DEBUGGER
-			_frp( FRP_WARN + "local simulation is still running, the network update will occur after completion" + FRP_END );
-			#endif
-
-			sn_updatelock = true;
-		}
-		else
-		{
-			// We are free to read this update
-			_netread();
-		}
-	}
-}
-
-#endregion
-
-#if !HT_QUEST
-
-const int FRP_MAX = 32;
-int FRP_LEN = 0;
-int FRP_PTR = 0;
-string[] FRP_LINES = new string[32];
-
-// Print a line to the debugger
-void _frp( string ln )
-{
-	Debug.Log( "[<color=\"#B5438F\">ht8b</color>] " + ln );
-
-	FRP_LINES[ FRP_PTR ++ ] = "[<color=\"#B5438F\">ht8b</color>] " + ln + "\n";
-	FRP_LEN ++ ;
-
-	if( FRP_PTR >= FRP_MAX )
-	{
-		FRP_PTR = 0;
-	}
-
-	if( FRP_LEN > FRP_MAX )
-	{
-		FRP_LEN = FRP_MAX;
-	}
-
-	string output = "ht8b 1.0.0aa ";
-		
-	// Add information about game state:
-	output += Networking.IsOwner(Networking.LocalPlayer, this.gameObject) ? 
-		"<color=\"#95a2b8\">net(</color> <color=\"#4287F5\">OWNER</color> <color=\"#95a2b8\">)</color> ":
-		"<color=\"#95a2b8\">net(</color> <color=\"#678AC2\">RECVR</color> <color=\"#95a2b8\">)</color> ";
-
-	output += sn_simulating ?
-		"<color=\"#95a2b8\">sim(</color> <color=\"#4287F5\">ACTIVE</color> <color=\"#95a2b8\">)</color> ":
-		"<color=\"#95a2b8\">sim(</color> <color=\"#678AC2\">PAUSED</color> <color=\"#95a2b8\">)</color> ";
-
-	VRCPlayerApi currentOwner = Networking.GetOwner( this.gameObject );
-	output += "<color=\"#95a2b8\">player(</color> <color=\"#4287F5\">"+ (currentOwner != null? currentOwner.displayName: "[null]") + ":" + sn_turnid + "</color> <color=\"#95a2b8\">)</color>";
-
-	output += "\n---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n";
-
-	// Update display 
-	for( int i = 0; i < FRP_LEN ; i ++ )
-	{
-		output += FRP_LINES[ (FRP_MAX + FRP_PTR - FRP_LEN + i) % FRP_MAX ];
-	}
-
-	ltext.text = output;
-}
-
+        // Intro animation
+        if (introAminTimer > 0.0f)
+        {
+            introAminTimer -= Time.deltaTime;
+
+            Vector3 temp;
+            float atime;
+            float aitime;
+
+            if (introAminTimer < 0.0f)
+                introAminTimer = 0.0f;
+
+            // Cueball drops late
+            temp = ballsToRender[0].transform.localPosition;
+            atime = Mathf.Clamp(introAminTimer - 0.33f, 0.0f, 1.0f);
+            aitime = (1.0f - atime);
+            temp.y = Mathf.Abs(Mathf.Cos(atime * 6.29f)) * atime * 0.5f;
+            ballsToRender[0].transform.localPosition = temp;
+            ballsToRender[0].transform.localScale = new Vector3(aitime, aitime, aitime);
+
+            for (int i = 1; i < 16; i++)
+            {
+                temp = ballsToRender[i].transform.localPosition;
+                atime = Mathf.Clamp(introAminTimer - 0.84f - (float)i * 0.03f, 0.0f, 1.0f);
+                aitime = (1.0f - atime);
+
+                temp.y = Mathf.Abs(Mathf.Cos(atime * 6.29f)) * atime * 0.5f;
+                ballsToRender[i].transform.localPosition = temp;
+                ballsToRender[i].transform.localScale = new Vector3(aitime, aitime, aitime);
+            }
+        }
+    }
+
+    // Wait for updates to the synced netstr
+    public override void OnDeserialization()
+    {
+        if (!string.Equals(newState, oldState))
+        {
+#if HT8B_DEBUGGER
+            _frp(FRP_LOW + "OnDeserialization() :: netstr update" + FRP_END);
 #endif
 
+            oldState = newState;
+
+            // Check if local simulation is in progress, the event will fire off later when physics
+            // are settled by the client
+            if (gameIsSimulating)
+            {
+#if HT8B_DEBUGGER
+                _frp(FRP_WARN + "local simulation is still running, the network update will occur after completion" + FRP_END);
+#endif
+
+                isUpdateLocked = true;
+            }
+            else
+            {
+                // We are free to read this update
+                ReadNetworkData();
+            }
+        }
+    }
+
+    public void PackNetworkDataLossily()
+    {
+        if (!isGameOver)
+        {
+#if HT8B_DEBUGGER
+            _frp(FRP_ERR + "Critical error: gameover was false when trying to _netpaclossy()" + FRP_END);
+#endif
+            return;
+        }
+
+        // Game state
+        uint flags = 0x20u;                     // bit #
+
+        // Since v1.0.0
+        flags |= gameMode << 8;              // 8  - 3 bits
+        flags |= timerType << 13;                // 13 - 2 bits
+        if (isTeams) flags |= 0x8000u;     // 15 - 1 bit
+        if (isLobbyClosed) flags |= 0x800u;
+
+        EncodeUint16(0x4C, (ushort)flags);
+
+        clock = (ushort)(clock + 1u);
+        EncodeUint16(0x4E, (ushort)(clock));
+        EncodeUint16(0x50, gameID);
+
+        newState = Convert.ToBase64String(networkData, Base64FormattingOptions.None);
+    }
+
+    // Encode all data of game state into netstr
+    public void PackNetworkData(uint _turnid)
+    {
+        if (localPlayerID < 0)
+        {
+#if HT8B_DEBUGGER
+            _frp(FRP_ERR + "Critical error: local_playerid was less than 0 when trying to NetPack()" + FRP_END);
+#endif
+            return;
+        }
+
+        // Garuntee array size by reallocating.. because c#
+        networkData = new byte[0x52];
+
+        for (int i = 0; i < 16; i++)
+        {
+            EncodeVector3(i * 4, ball_CO[i], 2.5f);
+        }
+
+        // Cue ball velocity & angular velocity last
+        EncodeVector3(0x40, ball_V[0], 50.0f);
+        EncodeVector3Full(0x44, ball_W[0], 500.0f);
+
+        if (isGameModeTwo)
+        {
+            // Encode player scores into gmspec
+            modeSpecficData = (ushort)(((uint)scores[0]) & 0x0fu);
+            modeSpecficData |= (ushort)((((uint)scores[1]) & 0x0fu) << 4);
+            if (isKorean) modeSpecficData |= (ushort)0x100u;
+
+            // 4 ball specifc ( no pocket info )
+            EncodeUint16(0x4A, modeSpecficData);
+        }
+        else
+        {
+            // Encode pocketed imformation
+            EncodeUint16(0x4A, (ushort)(ballPocketedState & 0x0000FFFFu));
+        }
+
+        // Game state
+        uint flags = 0x0U;                      // bit #
+        if (gameIsSimulating) flags |= 0x1U;   // 0
+        flags |= _turnid << 1;                  // 1
+        if (isFoul) flags |= 0x4U;         // 2
+        if (isOpen) flags |= 0x8U;         // 3
+        flags |= playerColours << 4;         // 4
+        if (isGameOver) flags |= 0x20u;    // 5
+        flags |= winnerID << 6;              // 6
+        if (isPlayerAllowedToPlay) flags |= 0x80U;      // 7
+
+        if (isLobbyClosed) flags |= 0x800u;
+
+        // Since v1.0.0
+        flags |= gameMode << 8;              // 8  - 3 bits
+        flags |= timerType << 13;                // 13 - 2 bits
+        if (isTeams) flags |= 0x8000u;     // 15 - 1 bit
+
+        EncodeUint16(0x4C, (ushort)flags);
+
+        // Player ID msb gets added to referee any discrepencies between clients
+        // Higher order players get priority because it will be less common
+        // to play 2v2, so we can save most packet id's for normal 1v1
+        uint msb_playerid = ((uint)localPlayerID & 0x2u) >> 1;
+
+        EncodeUint16(0x4E, (ushort)(clock + 1u + msb_playerid));
+        EncodeUint16(0x50, gameID);
+
+        newState = Convert.ToBase64String(networkData, Base64FormattingOptions.None);
+
+#if HT8B_DEBUGGER
+        _frp(FRP_LOW + "NetPack()" + FRP_END);
+#endif
+    }
+
+    // Decode networking string
+    // TODO: Clean up this function
+    public void ReadNetworkData()
+    {
+        // CHECK ERROR ===================================================================================================
+#if HT8B_DEBUGGER
+        _frp(FRP_LOW + "incoming base64: " + netstr + FRP_END);
+#endif
+
+        byte[] in_data = Convert.FromBase64String(newState);
+        if (in_data.Length < 0x52)
+        {
+
+#if HT8B_DEBUGGER
+            _frp(FRP_WARN + "Sync string too short for decode, skipping\n" + FRP_END);
+#endif
+
+            return;
+        }
+
+        networkData = in_data;
+
+#if HT8B_DEBUGGER
+        _frp(FRP_LOW + _netstr_hex() + FRP_END);
+#endif
+
+        // Throw out updates that are possible errournous
+        ushort nextid = DecodeUint16(0x4E);
+        if (nextid <= clock)
+        {
+#if HT8B_DEBUGGER
+            _frp(FRP_WARN + "Packet ID was old ( " + nextid + " <= " + sn_packetid + " ). Throwing out update" + FRP_END);
+#endif
+
+            return;
+        }
+        clock = nextid;
+
+        // MAIN DECODE ===================================================================================================
+        CopyCurrentValuesToPrevious();
+
+        // Pocketed information
+        // Ball positions, reset velocity
+
+        for (int i = 0; i < 16; i++)
+        {
+            ball_V[i] = Vector3.zero;
+            ball_W[i] = Vector3.zero;
+            ball_CO[i] = DecodeVector3(i * 4, 2.5f);
+        }
+
+        ball_V[0] = DecodeVector3(0x40, 50.0f);
+        ball_W[0] = DecodeVector3Full(0x44, 500.0f);
+
+        ballPocketedState = DecodeUint16(0x4A);
+
+        uint gamestate = DecodeUint16(0x4C);
+        gameIsSimulating = (gamestate & 0x1U) == 0x1U;
+        turnID = (gamestate & 0x2U) >> 1;
+        isFoul = (gamestate & 0x4U) == 0x4U;
+        isOpen = (gamestate & 0x8U) == 0x8U;
+        playerColours = (gamestate & 0x10U) >> 4;
+        isGameOver = (gamestate & 0x20U) == 0x20U;
+        winnerID = (gamestate & 0x40U) >> 6;
+        isPlayerAllowedToPlay = (gamestate & 0x80U) == 0x80U;
+        isLobbyClosed = (gamestate & 0x800u) == 0x800u;
+
+        // Since v1.0.0
+        gameMode = (gamestate & 0x700u) >> 8;            // 3 bits
+        timerType = (gamestate & 0x6000u) >> 13;         // 2 bits
+        isTeams = (gamestate & 0x8000u) == 0x8000u;        //
+
+        // TODO: allocate more bits to packet ID, less to game ID
+        gameID = DecodeUint16(0x50);
+
+        // Events ==========================================================================================================
+
+        if (gameID > oldGameID && !isGameOver)
+        {
+            // EV: 1
+#if HT8B_DEBUGGER
+            _frp(FRP_YES + " .EV: 1 (sn_gameid > sn_gameid_prv) -> NewGame" + FRP_END);
+#endif
+
+            OnLocalNewGame();
+        }
+
+        // Check if turn was transferred
+        if (turnID != oldTurnID)
+        {
+            // EV: 2
+#if HT8B_DEBUGGER
+            _frp(FRP_YES + " .EV: 2 (sn_turnid != sn_turnid_prv) -> NewTurn" + FRP_END);
+#endif
+
+            OnLocalTurnChange();
+        }
+
+        // Table switches to closed
+        if (oldOpen && !isOpen)
+        {
+            // EV: 3
+#if HT8B_DEBUGGER
+            _frp(FRP_YES + " .EV: 3 (sn_open_prv && !sn_open) -> DisplaySet" + FRP_END);
+#endif
+
+            OnLocalTableClosed();
+        }
+
+        // Check if game is over
+        if (!oldGameOver && isGameOver)
+        {
+            // EV: 4
+#if HT8B_DEBUGGER
+            _frp(FRP_YES + " .EV: 4 (!sn_gameover_prv && sn_gamemover) -> Gameover" + FRP_END);
+#endif
+
+            OnLocalGameOver();
+            return;
+        }
+
+        if (isGameOver)
+        {
+            ViewTimer();
+            ViewTeams();
+            ViewGameMode();
+            ViewJoin();
+            ViewMenu();
+            return;
+        }
+
+        // Effects colliders need to be turned off when not simulating
+        // to improve pickups being glitchy
+        if (gameIsSimulating)
+        {
+            fxColliderBase.SetActive(true);
+        }
+        else
+        {
+            fxColliderBase.SetActive(false);
+        }
+
+        if (isGameModeTwo)
+        {
+            modeSpecficData = DecodeUint16(0x4A);
+            scores[0] = (int)(modeSpecficData & 0x0fu);
+            scores[1] = (int)((modeSpecficData & 0xf0u) >> 4);
+
+            isKorean = (modeSpecficData & 0x100u) == 0x100u;
+            isJapanese = !isKorean;
+
+            ballPocketedState = 0xFDF2u;
+        }
+
+        // Check this every read
+        // Its basically 'turn start' event
+        if (isPlayerAllowedToPlay)
+        {
+            bool isOurTurn = ((localPlayerID >= 0) && (localTeamID == turnID)) || isGameModePractice;
+
+            // Check if teammate placed the positioner
+            if (!isFoul)
+            {
+#if HT8B_DEBUGGER
+                _frp(FRP_YES + " .EV: 3 (!sn_foul && sn_foul_prv && sn_permit) -> Marker placed" + FRP_END);
+#endif
+
+                isReposition = false;
+                marker.SetActive(false);
+            }
+
+#if !UNITY_ANDROID
+            if (isOurTurn)
+            {
+                // Update for desktop
+                AllowHit();
+            }
+            else
+            {
+                DenyHit();
+            }
+#endif
+
+            if (isGameModeOne)
+            {
+                int target = GetLowestNumberedBall(ballPocketedState);
+
+                marker9ball.SetActive(true);
+                marker9ball.transform.localPosition = ball_CO[target];
+            }
+
+#if !UNITY_ANDROID
+            RackBalls();
+#endif
+
+            if (timerType > 0 && !isTimerRunning)
+            {
+                ResetTimer();
+            }
+        }
+        else
+        {
+            marker9ball.SetActive(false);
+            isTimerRunning = false;
+            isMadePoint = false;
+            isMadeFoul = false;
+            isFirstHit = 0;
+            isSecondHit = 0;
+            isThirdHit = 0;
+
+            // These dissapeared from v1.0.0 for some reason
+            marker.SetActive(false);
+            devhit.SetActive(false);
+            guideline.SetActive(false);
+        }
+
+        OnLocalUpdateScoreCard();
+    }
+
+    // Resets local game state to defined state
+    // TODO: Merge this with NewGame()
+    public void SetupBreak()
+    {
+        gameIsSimulating = false;
+        isOpen = true;
+        isGameOver = false;
+        playerColours = 0;
+        winnerID = 0;
+
+        // Cue ball
+        ball_CO[0] = new Vector3(-SPOT_POSITION_X, 0.0f, 0.0f);
+        ball_V[0] = Vector3.zero;
+
+        // Start at spot
+
+        if (isGameModeOne) // 9 ball
+        {
+            ballPocketedState = 0xFC00u;
+
+            for (int i = 0, k = 0; i < 5; i++)
+            {
+                int rown = brearows_9ball[i];
+                for (int j = 0; j <= rown; j++)
+                {
+                    ball_CO[breaorder_9ball[k++]] = new Vector3
+                    (
+                        SPOT_POSITION_X + (float)i * BALL_PL_Y + UnityEngine.Random.Range(-RANDOMIZE_F, RANDOMIZE_F),
+                        0.0f,
+                        (float)(-rown + j * 2) * BALL_PL_X + UnityEngine.Random.Range(-RANDOMIZE_F, RANDOMIZE_F)
+                    );
+
+                    ball_V[k] = Vector3.zero;
+                    ball_W[k] = Vector3.zero;
+                }
+            }
+        }
+        else if (isGameModeTwo) // 4 ball
+        {
+            ballPocketedState = 0xFDF2u;
+
+            ball_CO[0] = new Vector3(-SPOT_CAROM_X, 0.0f, 0.0f);
+            ball_CO[9] = new Vector3(SPOT_CAROM_X, 0.0f, 0.0f);
+            ball_CO[2] = new Vector3(SPOT_POSITION_X, 0.0f, 0.0f);
+            ball_CO[3] = new Vector3(-SPOT_POSITION_X, 0.0f, 0.0f);
+
+            ball_V[0] = Vector3.zero;
+            ball_V[9] = Vector3.zero;
+            ball_V[2] = Vector3.zero;
+            ball_V[3] = Vector3.zero;
+
+            ball_W[0] = Vector3.zero;
+            ball_W[9] = Vector3.zero;
+            ball_W[2] = Vector3.zero;
+            ball_W[3] = Vector3.zero;
+        }
+        else // Normal 8 ball modes
+        {
+            ballPocketedState = 0x00u;
+
+            for (int i = 0, k = 0; i < 5; i++)
+            {
+                for (int j = 0; j <= i; j++)
+                {
+                    ball_CO[breaorder_8ball[k++]] = new Vector3
+                    (
+                        SPOT_POSITION_X + (float)i * BALL_PL_Y + UnityEngine.Random.Range(-RANDOMIZE_F, RANDOMIZE_F),
+                        0.0f,
+                        (float)(-i + j * 2) * BALL_PL_X + UnityEngine.Random.Range(-RANDOMIZE_F, RANDOMIZE_F)
+                    );
+
+                    ball_V[k] = Vector3.zero;
+                    ball_W[k] = Vector3.zero;
+                }
+            }
+        }
+
+        oldPocketed = ballPocketedState;
+    }
+    // Purpose: 
+    //  Public methods which should are called from other behaviours
+
+    // Player select 4 ball mode Japanese
+    public void SelectedJapaneseFourBall()
+    {
+        isJapanese = true;
+        isKorean = false;
+        isRegionSelected = true;
+        select4Ball.SetActive(false);
+
+        StartNewGame();
+    }
+
+    public void SelectedKoreanFourBall()
+    {
+        isJapanese = false;
+        isKorean = true;
+        isRegionSelected = true;
+        select4Ball.SetActive(false);
+
+        StartNewGame();
+    }
+
+    // Player is holding input trigger
+    public void StartHit()
+    {
+        // lock aim variables
+        bool isOurTurn = ((localPlayerID >= 0) && (localTeamID == turnID)) || isGameModePractice;
+
+        if (isOurTurn)
+        {
+            isArmed = true;
+
+#if !UNITY_ANDROID
+            guidelineMat.SetColor("_Colour", aimLocked);
+#endif
+        }
+    }
+
+    // Player stopped holding input trigger
+    public void EndHit()
+    {
+        isArmed = false;
+
+#if !UNITY_ANDROID
+        guidelineMat.SetColor("_Colour", aimAiming);
+#endif
+    }
+
+    // Player was moving cueball, place it down
+    public void PlaceBall()
+    {
+        if (!IsCueContacting())
+        {
+            isReposition = false;
+            marker.SetActive(false);
+
+            isPlayerAllowedToPlay = true;
+            isFoul = false;
+
+            Networking.SetOwner(Networking.LocalPlayer, this.gameObject);
+
+            // Save out position to remote clients
+            PackNetworkData(turnID);
+            ReadNetworkData();
+        }
+    }
+
+    // Initialize new match as the host
+    public void StartNewGame()
+    {
+        // Check if game in progress
+        if (isGameOver)
+        {
+#if HT8B_DEBUGGER
+            _frp(FRP_YES + "Starting new game" + FRP_END);
+#endif
+
+            // Get gamestate rolling
+            gameID++;
+            isPlayerAllowedToPlay = true;
+
+            OnLocalNewGame();
+
+            turnID = 0;
+            oldTurnID = 0;
+            OnLocalTurnChange();
+
+            // Following is overrides of NewGameLocal, for game STARTER only
+            SetupBreak();
+            ApplyTableColour(0);
+
+            Networking.SetOwner(Networking.LocalPlayer, this.gameObject);
+            PackNetworkData(0);
+            ReadNetworkData();
+
+            // Override allow repositioning within kitchen
+            // Local effector
+            isReposition = true;
+            repoMaxX = -SPOT_POSITION_X;
+            marker.transform.localPosition = ball_CO[0];
+            marker.SetActive(true);
+
+            if (!isRegionSelected)
+            {
+                if (gameMode == 2u)
+                {
+                    select4Ball.SetActive(true);
+                    return;
+                }
+            }
+        }
+        else
+        {
+            // Should not be hit since v1.0.0
+#if HT8B_DEBUGGER
+            _frp(FRP_ERR + "game in progress" + FRP_END);
+#endif
+        }
+    }
+
+    // Completely reset ht8b state
+    public void ForceReset()
+    {
+        // Limit reset to totem owners ownly, this will always be someone in the room
+        // but it may not be obvious to players who has the ownership. So a info text
+        // is added above the reset button telling them who can reset if they dont have it
+        // this is simply to prevent trolls running in and force resetting at random
+
+        if (Networking.LocalPlayer == Networking.GetOwner(playerTotems[0]) ||
+            Networking.LocalPlayer == Networking.GetOwner(playerTotems[1])
+            || isGameOver)
+        {
+#if HT8B_DEBUGGER
+            _frp(FRP_WARN + "Ending game early" + FRP_END);
+#endif
+
+            isGameOver = true;
+            isPlayerAllowedToPlay = false;
+            gameIsSimulating = false;
+
+            // For good measure in case other clients trigger an event whilst owner
+            clock += 2;
+
+            Networking.SetOwner(Networking.LocalPlayer, this.gameObject);
+            PackNetworkData(turnID);
+            ReadNetworkData();
+
+            OnLocalGameOver();
+
+            resetMessage.text = "Reset";
+        }
+        else
+        {
+            // TODO: Make this a panel
+#if HT8B_DEBUGGER
+            _frp(FRP_ERR + "Reset is availible to: " + Networking.GetOwner(playerTotems[0]).displayName + " and " + Networking.GetOwner(playerTotems[1]).displayName + FRP_END);
+#endif
+
+            resetMessage.text = "Only:\n" + Networking.GetOwner(playerTotems[0]).displayName + " and " + Networking.GetOwner(playerTotems[1]).displayName + "\ncan reset";
+        }
+    }
+
+    // Cue picked up local
+    public void OnPickupCueLocally()
+    {
+        isDesktopShootUI = true;
+        isDesktopFrameIgnore = true;
+        desktopBase.SetActive(true);
+
+        // Lock player in place
+        Networking.LocalPlayer.SetWalkSpeed(0.0f);
+        Networking.LocalPlayer.SetRunSpeed(0.0f);
+        Networking.LocalPlayer.SetStrafeSpeed(0.0f);
+
+#if HT8B_DEBUGGER
+        _frp(FRP_LOW + "Entering desktop overlay" + FRP_END);
+#endif
+    }
+
+    // Cue put down local
+    public void OnPutDownCueLocally()
+    {
+        OnDesktopUIExit();
+    }
+
+    public void UpdateColourSources()
+    {
+        if (isGameModeOne)    // 9 Ball / USA colours
+        {
+            pointerColour0 = tableLightBlue;
+            pointerColour1 = tableLightBlue;
+            pointerColour2 = tableLightBlue;
+
+            pointerColourErr = tableBlack;    // No error effect
+            pointerClothColour = fabricBlue;
+
+            // 9 ball only uses one colourset / cloth colour
+            ballMaterial.SetTexture("_MainTex", sets[3]);
+        }
+        else if (isGameModeTwo)
+        {
+            pointerColour0 = tableWhite;
+            pointerColour1 = tableYellow;
+
+            // Should not be used
+            pointerColour2 = tableRed;
+            pointerColourErr = tableRed;
+
+            ballMaterial.SetTexture("_MainTex", sets[2]);
+            pointerClothColour = fabricGreen;
+        }
+        else // Standard 8 ball derivatives
+        {
+            pointerColourErr = tableRed;
+            pointerColour2 = tableWhite;
+
+            pointerColour0 = tableBlue;
+            pointerColour1 = tableOrange;
+
+            ballMaterial.SetTexture("_MainTex", sets[0]);
+            pointerClothColour = fabricGray;
+        }
+        tableMaterial.SetColor("_ClothColour", pointerClothColour);
+        tableReflection.RenderProbe();
+    }
+
+    // Updates table colour target to appropriate player colour
+    private void ApplyTableColour(uint idsrc)
+    {
+        if (isGameModeTwo)
+        {
+            if (turnID == 0)
+            {
+                cueRenderObjs[0].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, pointerColour0);
+                cueRenderObjs[1].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, pointerColour1 * 0.5f);
+            }
+            else
+            {
+                cueRenderObjs[0].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, pointerColour0 * 0.5f);
+                cueRenderObjs[1].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, pointerColour1);
+            }
+
+            tableSrcColour = tableBlack;
+        }
+
+        else if (isGameModeOne)
+        {
+            cueRenderObjs[turnID].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, tableWhite);
+            cueRenderObjs[turnID ^ 0x1u].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, tableBlack);
+
+            tableSrcColour = pointerColour2;
+        }
+
+        else
+        {
+            if (!isOpen)
+            {
+                if ((idsrc ^ playerColours) == 0)
+                {
+                    // Set table colour to blue
+                    tableSrcColour = pointerColour0;
+                }
+                else
+                {
+                    // Table colour to orange
+                    tableSrcColour = pointerColour1;
+                }
+
+                cueRenderObjs[playerColours].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, pointerColour0);
+                cueRenderObjs[playerColours ^ 0x1u].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, pointerColour1);
+            }
+            else
+            {
+                tableSrcColour = pointerColour2;
+
+                cueRenderObjs[turnID].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, tableWhite);
+                cueRenderObjs[turnID ^ 0x1u].GetComponent<MeshRenderer>().sharedMaterial.SetColor(unofmrCueColour, tableBlack);
+            }
+
+        }
+
+        cueGrips[turnID].SetColor(uniformMarkerColour, gripColourActive);
+        cueGrips[turnID ^ 0x1u].SetColor(uniformMarkerColour, gripColourInactive);
+    }
+
+    private void ShowBalls()
+    {
+        if (isGameModeOne)
+        {
+            for (int i = 0; i <= 9; i++)
+                ballsToRender[i].SetActive(true);
+
+            for (int i = 10; i < 16; i++)
+                ballsToRender[i].SetActive(false);
+        }
+        else if (isGameModeTwo)
+        {
+            for (int i = 1; i < 16; i++)
+                ballsToRender[i].SetActive(false);
+
+            ballsToRender[0].SetActive(true);
+            ballsToRender[2].SetActive(true);
+            ballsToRender[3].SetActive(true);
+            ballsToRender[9].SetActive(true);
+        }
+        else
+        {
+            for (int i = 0; i < 16; i++)
+            {
+                ballsToRender[i].SetActive(true);
+            }
+        }
+    }
+
+    private void DisableObjects()
+    {
+        guideline.SetActive(false);
+        devhit.SetActive(false);
+        infBaseTransform.SetActive(false);
+        marker.SetActive(false);
+        tableOverlayUI.SetActive(false);
+        marker9ball.SetActive(false);
+        point4Ball.SetActive(false);
+        select4Ball.SetActive(false);
+    }
+
+    private void SpawnFloaty(Vector3 pos, Mesh m)
+    {
+        point4Ball.SetActive(true);
+        isParticleAlive = true;
+        particleTime = 0.1f;
+
+        // orient to be looking at player
+        Vector3 lpos = Networking.LocalPlayer.GetPosition();
+        Vector3 delta = lpos - this.transform.TransformPoint(pos);
+        float r = Mathf.Atan2(delta.x, delta.z);
+        point4Ball.transform.localRotation = Quaternion.AngleAxis(r * Mathf.Rad2Deg, Vector3.up);
+
+        // set position
+        point4Ball.transform.localPosition = pos;
+
+        // Set scale
+        point4Ball.transform.localScale = Vector3.zero;
+
+        point4Ball.GetComponent<MeshFilter>().sharedMesh = m;
+    }
+
+    private void FloatyEval()
+    {
+        float scale, s, v, e;
+
+        // Evaluate time
+        particleTime += Time.deltaTime * 0.25f;
+
+        // Sustained step
+        s = Mathf.Max(particleTime - 0.1f, 0.0f);
+        v = Mathf.Min(particleTime * particleTime * 100.0f, 21.0f * s * Mathf.Exp(-15.0f * s));
+
+        // Exponential step
+        e = Mathf.Exp(-17.0f * Mathf.Pow(Mathf.Max(particleTime - 1.2f, 0.0f), 3.0f));
+
+        scale = e * v * 2.0f;
+
+        // Set scale
+        point4Ball.transform.localScale = new Vector3(scale, scale, scale);
+
+        // Set position
+        Vector3 temp = point4Ball.transform.localPosition;
+        temp.y = particleTime * 0.5f;
+        point4Ball.transform.localPosition = temp;
+
+        // Particle death
+        if (particleTime > 2.0f)
+        {
+            isParticleAlive = false;
+            point4Ball.SetActive(false);
+        }
+    }
+
+    private void ResetTimer()
+    {
+        if (timerType == 0)
+        {
+            timerEnd = Time.timeSinceLevelLoad + 30.0f;
+            timerRecp = 0.03333333333f;
+        }
+        else
+        {
+            timerEnd = Time.timeSinceLevelLoad + 60.0f;
+            timerRecp = 0.01666666666f;
+        }
+
+        isTimerRunning = true;
+    }
+
+    private void OnLocalCaromPoint(Vector3 p)
+    {
+        isMadePoint = true;
+        mainSrc.PlayOneShot(pointMadeSfx, 1.0f);
+
+        scores[turnID]++;
+
+        if (scores[turnID] > 10)
+        {
+            scores[turnID] = 10;
+        }
+
+        SpawnFloaty(p, fourBallAdd);
+    }
+
+    private void OnLocalCaromPenalize(Vector3 p)
+    {
+        isMadeFoul = true;
+        //aud_main.PlayOneShot( snd_bad, 1.0f );
+
+        scores[turnID]--;
+
+        if (scores[turnID] < 0)
+        {
+            scores[turnID] = 0;
+        }
+
+        SpawnFloaty(p, fourBallMinus);
+    }
+
+    // Called when a player first sinks a ball whilst the table was previously open
+    private void OnLocalTableClosed()
+    {
+        uint picker = turnID ^ playerColours;
+        ApplyTableColour(turnID);
+        OnLocalUpdateScoreCard();
+
+        scoreCardRenderer.sharedMaterial.SetColor(uniformScoreCardColour0, playerColours == 0 ? pointerColour0 : pointerColour1);
+        scoreCardRenderer.sharedMaterial.SetColor(uniformScoreCardColour1, playerColours == 1 ? pointerColour0 : pointerColour1);
+    }
+
+    // End of the game. Both with/loss
+    private void OnLocalGameOver()
+    {
+        ApplyTableColour(winnerID);
+
+        winMessage.text = Networking.GetOwner(playerTotems[winnerID]).displayName + " wins!";
+        infBaseTransform.SetActive(true);
+        marker9ball.SetActive(false);
+        tableOverlayUI.SetActive(false);
+
+#if !UNITY_ANDROID
+        RackBalls();   // To make sure rigidbodies are completely off
+#endif
+
+        isReposition = false;
+        marker.SetActive(false);
+
+        OnLocalUpdateScoreCard();
+
+        // Remove any access rights
+        localPlayerID = -1;
+        GrantCueAccess();
+
+        EnterMenu();
+    }
+
+    private void OnLocalTurnChange()
+    {
+        // Effects
+        ApplyTableColour(turnID);
+        mainSrc.PlayOneShot(newTurnSfx, 1.0f);
+
+        // Register correct cuetip
+        cueTip = cueTips[turnID];
+
+        bool isOurTurn = ((localPlayerID >= 0) && (localTeamID == turnID)) || isGameModePractice;
+
+        if (isGameModeTwo) // 4 ball
+        {
+            // Swap cue ball and opponent cue
+            Vector3 temp = ball_CO[0];
+            ball_CO[0] = ball_CO[9];
+            ball_CO[9] = temp;
+
+            if (turnID == 0)
+            {
+                ballsToRender[0].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[0];
+                ballsToRender[9].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[1];
+            }
+            else
+            {
+                ballsToRender[9].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[0];
+                ballsToRender[0].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[1];
+            }
+        }
+        else
+        {
+            // White was pocketed
+            if ((ballPocketedState & 0x1u) == 0x1u)
+            {
+                ball_CO[0] = Vector3.zero;
+                ball_V[0] = Vector3.zero;
+                ball_W[0] = Vector3.zero;
+
+                ballPocketedState &= 0xFFFFFFFEu;
+            }
+        }
+
+        if (isOurTurn)
+        {
+            if (isFoul)
+            {
+                isReposition = true;
+                repoMaxX = TABLE_WIDTH;
+                marker.SetActive(true);
+
+                marker.transform.localPosition = ball_CO[0];
+            }
+        }
+
+        // Force timer reset
+        if (timerType > 0)
+        {
+            ResetTimer();
+        }
+    }
+
+    private void OnLocalUpdateScoreCard()
+    {
+        if (isGameModeTwo)
+        {
+            scoreCardRenderer.sharedMaterial.SetVector(uniformScoreCardInfo, new Vector4(scores[0] * 0.04681905f, scores[1] * 0.04681905f, 0.0f, 0.0f));
+        }
+        else
+        {
+            int[] counter0 = new int[2];
+
+            uint temp = ballPocketedState;
+
+            for (int j = 0; j < 2; j++)
+            {
+                for (int i = 0; i < 7; i++)
+                {
+                    if ((temp & 0x4) > 0)
+                    {
+                        counter0[j ^ playerColours]++;
+                    }
+
+                    temp >>= 1;
+                }
+            }
+
+            // Add black ball if we are winning the thing
+            if (isGameOver)
+            {
+                counter0[winnerID] += (int)((ballPocketedState & 0x2) >> 1);
+            }
+
+            scoreCardRenderer.sharedMaterial.SetVector(uniformScoreCardInfo, new Vector4(counter0[0] * 0.0625f, counter0[1] * 0.0625f, 0.0f, 0.0f));
+        }
+    }
+
+    // Player scored an objective ball 
+    private void OnLocalPocketObject()
+    {
+        // Make a bright flash
+        tableCurrentColour *= 1.9f;
+
+        mainSrc.PlayOneShot(sinkSfx, 1.0f);
+    }
+
+    // Player scored a foul ball (cue, non-objective or 8 before set cleared)
+    private void OnLocalPocketFoulBall()
+    {
+        tableCurrentColour = pointerColourErr;
+
+        mainSrc.PlayOneShot(sinkSfx, 1.0f);
+    }
+
+    // once balls stops rolling this is called
+    private void OnLocalSimulationEnd()
+    {
+        gameIsSimulating = false;
+
+        // Make sure we only run this from the client who initiated the move
+        if (isSimulatedByUs)
+        {
+            isSimulatedByUs = false;
+
+            // We are updating the game state so make sure we are network owner
+            Networking.SetOwner(Networking.LocalPlayer, this.gameObject);
+
+            // Owner state checks
+
+            uint bmask = 0xFFFCu;
+            uint emask = 0x0u;
+
+            // Quash down the mask if table has closed
+            if (!isOpen)
+            {
+                bmask = bmask & (0x1FCu << ((int)(playerColours ^ turnID) * 7));
+                emask = 0x1FCu << ((int)(playerColours ^ turnID ^ 0x1U) * 7);
+            }
+
+            // Common informations
+            bool isSetComplete = (ballPocketedState & bmask) == bmask;
+            bool isScratch = (ballPocketedState & 0x1U) == 0x1U;
+
+            // Append black to mask if set is done
+            if (isSetComplete)
+            {
+                bmask |= 0x2U;
+            }
+
+            // These are the resultant states we can set for each mode
+            // then the rest is taken care of
+            bool
+                isObjectiveSink,
+                isOpponentSink,
+                winCondition,
+                foulCondition,
+                deferLossCondition
+            ;
+
+            if (isGameModeZero)    // Standard 8 ball
+            {
+                isObjectiveSink = (ballPocketedState & bmask) > (oldPocketed & bmask);
+                isOpponentSink = (ballPocketedState & emask) > (oldPocketed & emask);
+
+                // Calculate if objective was not hit first
+                bool isWrongHit = ((0x1U << isFirstHit) & bmask) == 0;
+
+                bool is8Sink = (ballPocketedState & 0x2U) == 0x2U;
+
+                winCondition = isSetComplete && is8Sink;
+                foulCondition = isScratch || isWrongHit;
+
+                deferLossCondition = is8Sink;
+            }
+            else if (isGameModeOne)   // 9 ball
+            {
+                // Rules are from: https://www.youtube.com/watch?v=U0SbHOXCtFw
+
+                // Rule #1: Cueball must strike the lowest number ball, first
+                bool isWrongHit = !(GetLowestNumberedBall(oldPocketed) == isFirstHit);
+
+                // Rule #2: Pocketing cueball, is a foul
+
+                // Win condition: Pocket 9 ball ( at anytime )
+                winCondition = (ballPocketedState & 0x200u) == 0x200u;
+
+                // this video is hard to follow so im just gonna guess this is right
+                isObjectiveSink = (ballPocketedState & 0x3FEu) > (oldPocketed & 0x3FEu);
+
+                isOpponentSink = false;
+                deferLossCondition = false;
+
+                foulCondition = isWrongHit || isScratch;
+
+                // TODO: Implement rail contact requirement
+            }
+            else if (isGameModeTwo) // 4 ball
+            {
+                isObjectiveSink = isMadePoint;
+                isOpponentSink = isMadeFoul;
+                foulCondition = false;
+                deferLossCondition = false;
+
+                winCondition = scores[turnID] >= 10;
+            }
+            else // Unkown mode
+            {
+                isObjectiveSink = true;
+                isOpponentSink = false;
+                winCondition = false;
+                foulCondition = false;
+                deferLossCondition = false;
+
+                if ((ballPocketedState & 0x1u) == 0x1u)
+                {
+                    isFoul = true;
+                    OnLocalTurnChange();
+                }
+            }
+
+            if (winCondition)
+            {
+                if (foulCondition)
+                {
+                    // Loss
+                    OnTurnOverGameWon(turnID ^ 0x1U);
+                }
+                else
+                {
+                    // Win
+                    OnTurnOverGameWon(turnID);
+                }
+            }
+            else if (deferLossCondition)
+            {
+                // Loss
+                OnTurnOverGameWon(turnID ^ 0x1U);
+            }
+            else if (foulCondition)
+            {
+                // Foul
+                OnTurnOverFoul();
+            }
+            else if (isObjectiveSink && !isOpponentSink)
+            {
+                // Continue
+                OnTurnOverContinue();
+            }
+            else
+            {
+                // Pass
+                OnTurnOverPassed();
+            }
+        }
+
+        // Check if there was a network update on hold
+        if (isUpdateLocked)
+        {
+            isUpdateLocked = false;
+
+            ReadNetworkData();
+        }
+    }
+
+    private void OnLocalTimerEnd()
+    {
+        isTimerRunning = false;
+
+        // We are holding the stick so propogate the change
+        if (Networking.GetOwner(playerTotems[turnID]) == Networking.LocalPlayer)
+        {
+            Networking.SetOwner(Networking.LocalPlayer, this.gameObject);
+            OnTurnOverFoul();
+        }
+        else
+        {
+            // All local players freeze until next target
+            // can pick up and propogate timer end
+            isPlayerAllowedToPlay = false;
+        }
+    }
+
+    // Grant cue access if we are playing
+    private void GrantCueAccess()
+    {
+        if (localPlayerID >= 0)
+        {
+            if (isGameModePractice)
+            {
+                gripControllers[0].AllowAccess();
+                gripControllers[1].AllowAccess();
+            }
+            else
+            {
+                if ((localTeamID & 0x1) > 0)                       // Local player is 1, or 3
+                {
+                    gripControllers[1].AllowAccess();
+                    gripControllers[0].DenyAccess();
+                }
+                else                                                            // Local player is 0, or 2
+                {
+                    gripControllers[0].AllowAccess();
+                    gripControllers[1].DenyAccess();
+                }
+            }
+        }
+        else
+        {
+            gripControllers[0].DenyAccess();
+            gripControllers[1].DenyAccess();
+        }
+    }
+
+    // Some udon specific optimisations
+    private void SetupOptimiziations()
+    {
+        isGameModeZero = gameMode == 0u;
+        isGameModeOne = gameMode == 1u;
+        isGameModeTwo = gameMode == 2u;
+    }
+
+    private void OnLocalNewGame()
+    {
+        SetupOptimiziations();
+
+        // Calculate interpreted values from menu states
+        if (localPlayerID >= 0)
+            localTeamID = (uint)localPlayerID & 0x1u;
+
+        // Disable menu
+        ExitMenu();
+
+        // Reflect menu-state settings (for late joiners)
+        UpdateColourSources();
+        ApplyTableColour(0);
+        GrantCueAccess();
+
+        // TODO: move to function
+        if (isGameModeOne)    // 9 ball specific
+        {
+            scoreCardRenderer.gameObject.SetActive(false);
+            marker9ball.SetActive(true);
+        }
+        else
+        {
+            scoreCardRenderer.gameObject.SetActive(true);
+            marker9ball.SetActive(false);
+        }
+
+        if (isGameModeTwo) // 4 ball specific
+        {
+            pocketBlockers.SetActive(true);
+            scoreCardRenderer.sharedMaterial.SetTexture("_MainTex", scoreCard4Ball);
+
+            scoreCardRenderer.sharedMaterial.SetColor(uniformScoreCardColour0, pointerColour0);
+            scoreCardRenderer.sharedMaterial.SetColor(uniformScoreCardColour1, pointerColour1);
+
+            scores[0] = 0;
+            scores[1] = 0;
+
+            // Reset mesh filters on balls that change them
+            ballsToRender[0].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[0];
+            ballsToRender[9].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[1];
+        }
+        else
+        {
+            pocketBlockers.SetActive(false);
+            scoreCardRenderer.sharedMaterial.SetTexture("_MainTex", scoreCard8Ball);
+
+            // Reset mesh filters on balls that change them
+            ballsToRender[0].GetComponent<MeshFilter>().sharedMesh = cueball_meshes[0];
+            ballsToRender[9].GetComponent<MeshFilter>().sharedMesh = nineBall;
+        }
+
+
+        ShowBalls();
+
+        // Reflect game state
+        OnLocalUpdateScoreCard();
+        isReposition = false;
+        marker.SetActive(false);
+        infBaseTransform.SetActive(false);
+
+        // Effects
+        introAminTimer = 2.0f;
+        mainSrc.PlayOneShot(introSfx, 1.0f);
+
+        // Player name texts
+        string base_text = "";
+        if (isTeams)
+        {
+            base_text = "Team ";
+        }
+
+        tableOverlayUI.SetActive(true);
+        playerNames[0].text = base_text + Networking.GetOwner(playerTotems[0]).displayName;
+        playerNames[1].text = base_text + Networking.GetOwner(playerTotems[1]).displayName;
+
+        isTimerRunning = false;
+
+        // Switch desktop/vr
+        bool usr_desktop = !Networking.LocalPlayer.IsUserInVR();
+
+#if !UNITY_ANDROID
+        gripControllers[0].useDesktop = usr_desktop;
+        gripControllers[1].useDesktop = usr_desktop;
+#endif
+    }
+
+#if !UNITY_ANDROID
+    // Finalize positions onto their rack spots
+    private void RackBalls()
+    {
+        uint ball_bit = 0x1u;
+
+        for (int i = 0; i < 16; i++)
+        {
+            ballsToRender[i].GetComponent<Rigidbody>().isKinematic = true;
+
+            if ((ball_bit & ballPocketedState) == ball_bit)
+            {
+                ballsToRender[i].transform.localPosition = new Vector3(
+                    ball_CO[i].x,
+                    RACHEIGHT,
+                    ball_CO[i].z
+                );
+            }
+
+            ball_bit <<= 1;
+        }
+    }
+#endif
+
+    // Internal game state pocket and enable unity physics to play out the rest
+    private void PocketBalls(int id)
+    {
+        uint total = 0U;
+
+        // Get total for X positioning
+        int count_extent = isGameModeOne ? 10 : 16;
+        for (int i = 1; i < count_extent; i++)
+        {
+            total += (ballPocketedState >> i) & 0x1U;
+        }
+
+        // set this for later
+        ball_CO[id].x = -0.9847f + (float)total * BALL_DIAMETRE;
+        ball_CO[id].z = 0.768f;
+
+        ballPocketedState ^= 1U << id;
+
+        uint bmask = 0x1FCU << ((int)(turnID ^ playerColours) * 7);
+
+        // Good pocket
+        if (((0x1U << id) & ((bmask) | (isOpen ? 0xFFFCU : 0x0000U) | ((bmask & ballPocketedState) == bmask ? 0x2U : 0x0U))) > 0)
+        {
+            OnLocalPocketObject();
+        }
+        else
+        {
+            // bad
+            OnLocalPocketFoulBall();
+        }
+
+#if !UNITY_ANDROID
+
+        // VFX ( make ball move )
+        Rigidbody body = ballsToRender[id].GetComponent<Rigidbody>();
+        body.isKinematic = false;
+        body.velocity = new Vector3(
+
+            ball_V[id].x,
+            0.0f,
+            ball_V[id].z
+
+        );
+
+#else
+
+	ballsToRender[ id ].transform.position = new Vector3(
+
+		ball_CO[ id ].x,
+		RACHEIGHT,
+		ball_CO[ id ].y
+	
+	);
+#endif
+    }
+
+    // Is cue touching another ball?
+    private bool IsCueContacting()
+    {
+        // 8 ball, practice, portal
+        if (gameMode != 1u)
+        {
+            // Check all
+            for (int i = 1; i < 16; i++)
+            {
+                if ((ball_CO[0] - ball_CO[i]).sqrMagnitude < BALL_DSQR)
+                {
+                    return true;
+                }
+            }
+        }
+        else // 9 ball
+        {
+            // Only check to 9 ball
+            for (int i = 1; i <= 9; i++)
+            {
+                if ((ball_CO[0] - ball_CO[i]).sqrMagnitude < BALL_DSQR)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // Check pocket condition
+    private void CheckPockets(int id)
+    {
+        float zz, zx;
+        Vector3 A;
+
+        A = ball_CO[id];
+
+        // Setup major regions
+        zx = Mathf.Sign(A.x);
+        zz = Mathf.Sign(A.z);
+
+        // Its in a pocket
+        if (A.z * zz > TABLE_HEIGHT + POCKET_DEPTH || A.z * zz > A.x * -zx + TABLE_WIDTH + TABLE_HEIGHT + POCKET_DEPTH)
+        {
+            PocketBalls(id);
+        }
+    }
+
+    // Apply cushion bounce
+    private void ApplyBounceCushion(int id, Vector3 N)
+    {
+        // Mathematical expressions derived from: https://billiards.colostate.edu/physics_articles/Mathavan_IMechE_2010.pdf
+        //
+        // (Note): subscript gamma, u, are used in replacement of Y and Z in these expressions because
+        // unicode does not have them.
+        //
+        // f = 2/7
+        // f₁ = 5/7
+        // 
+        // Velocity delta:
+        //   Δvₓ = −vₓ∙( f∙sin²θ + (1+e)∙cos²θ ) − Rωᵤ∙sinθ
+        //   Δvᵧ = 0
+        //   Δvᵤ = f₁∙vᵤ + fR( ωₓ∙sinθ - ωᵧ∙cosθ ) - vᵤ
+        //
+        // Aux:
+        //   Sₓ = vₓ∙sinθ - vᵧ∙cosθ+ωᵤ
+        //   Sᵧ = 0
+        //   Sᵤ = -vᵤ - ωᵧ∙cosθ + ωₓ∙cosθ
+        //   
+        //   k = (5∙Sᵤ) / ( 2∙mRA ); 
+        //   c = vₓ∙cosθ - vᵧ∙cosθ
+        //
+        // Angular delta:
+        //   ωₓ = k∙sinθ
+        //   ωᵧ = k∙cosθ
+        //   ωᵤ = (5/(2m))∙(-Sₓ / A + ((sinθ∙c∙(e+1)) / B)∙(cosθ - sinθ));
+        //
+        // These expressions are in the reference frame of the cushion, so V and ω inputs need to be rotated
+
+        // Reject bounce if velocity is going the same way as normal
+        // this state means we tunneled, but it happens only on the corner
+        // vertexes
+        Vector3 source_v = ball_V[id];
+        if (Vector3.Dot(source_v, N) > 0.0f)
+        {
+            return;
+        }
+
+        // Rotate V, W to be in the reference frame of cushion
+        Quaternion rq = Quaternion.AngleAxis(Mathf.Atan2(-N.z, -N.x) * Mathf.Rad2Deg, Vector3.up);
+        Quaternion rb = Quaternion.Inverse(rq);
+        Vector3 V = rq * source_v;
+        Vector3 W = rq * ball_W[id];
+
+        Vector3 V1;
+        Vector3 W1;
+        float k, c, s_x, s_z;
+
+        //V1.x = -V.x * ((2.0f/7.0f) * SINA2 + EP1 * COSA2) - (2.0f/7.0f) * BALL_PL_X * W.z * SINA;
+        //V1.z = (5.0f/7.0f)*V.z + (2.0f/7.0f) * BALL_PL_X * (W.x * SINA - W.y * COSA) - V.z;
+        //V1.y = 0.0f; 
+        // (baked):
+        V1.x = -V.x * F - 0.00240675711f * W.z;
+        V1.z = 0.71428571428f * V.z + 0.00857142857f * (W.x * SINA - W.y * COSA) - V.z;
+        V1.y = 0.0f;
+
+        // s_x = V.x * SINA - V.y * COSA + W.z;
+        // (baked): y component not used:
+        s_x = V.x * SINA + W.z;
+        s_z = -V.z - W.y * COSA + W.x * SINA;
+
+        // k = (5.0f * s_z) / ( 2 * BALL_MASS * A ); 
+        // (baked):
+        k = s_z * 0.71428571428f;
+
+        // c = V.x * COSA - V.y * COSA;
+        // (baked): y component not used
+        c = V.x * COSA;
+
+        W1.x = k * SINA;
+
+        //W1.z = (5.0f / (2.0f * BALL_MASS)) * (-s_x / A + ((SINA * c * EP1) / B) * (COSA - SINA));
+        // (baked):
+        W1.z = 15.625f * (-s_x * 0.04571428571f + c * 0.0546021744f);
+        W1.y = k * COSA;
+
+        // Unrotate result
+        ball_V[id] += rb * V1;
+        ball_W[id] += rb * W1;
+    }
+
+    // Pocketless table
+    private void BallTableCarom(int id)
+    {
+        float zz, zx;
+        Vector3 A;
+
+        A = ball_CO[id];
+
+        // Setup major regions
+        zx = Mathf.Sign(A.x);
+        zz = Mathf.Sign(A.z);
+
+        if (A.x * zx > TABLE_WIDTH)
+        {
+            ball_CO[id].x = TABLE_WIDTH * zx;
+            ApplyBounceCushion(id, Vector3.left * zx);
+        }
+
+        if (A.z * zz > TABLE_HEIGHT)
+        {
+            ball_CO[id].z = TABLE_HEIGHT * zz;
+            ApplyBounceCushion(id, Vector3.back * zz);
+        }
+    }
+
+    // TODO: inline this
+    // Xiexe: I think that this is a rather cursed way to handle table edge collision detections and I think there's maybe a less cursed way to do it.
+    private void HandleTableEdgeCollision(int id)
+    {
+        float zy, zx, zk, zw, d, k, i, j, l, r;
+        Vector3 A, N;
+
+        A = ball_CO[id];
+
+        // REGIONS
+        /*  
+            *  QUADS:							SUBSECTION:				SUBSECTION:
+            *    zx, zy:							zz:						zw:
+            *																
+            *  o----o----o  +:  1			\_________/				\_________/
+            *  | -+ | ++ |  -: -1		     |	    /		              /  /
+            *  |----+----|					  -  |  +   |		      -     /   |
+            *  | -- | +- |						  |	   |		          /  +  |
+            *  o----o----o						  |      |             /       |
+            * 
+            */
+
+        // Setup major regions
+        zx = Mathf.Sign(A.x);
+        zy = Mathf.Sign(A.z);
+
+        // within pocket regions
+        if ((A.z * zy > (TABLE_HEIGHT - POCKET_RADIUS)) && (A.x * zx > (TABLE_WIDTH - POCKET_RADIUS) || A.x * zx < POCKET_RADIUS))
+        {
+            // Subregions
+            zw = A.z * zy > A.x * zx - TABLE_WIDTH + TABLE_HEIGHT ? 1.0f : -1.0f;
+
+            // Normalization / line coefficients change depending on sub-region
+            if (A.x * zx > TABLE_WIDTH * 0.5f)
+            {
+                zk = 1.0f;
+                r = ONE_OVER_ROOT_TWO;
+            }
+            else
+            {
+                zk = -2.0f;
+                r = ONE_OVER_ROOT_FIVE;
+            }
+
+            // Collider line EQ
+            d = zx * zy * zk; // Coefficient
+            k = (-(TABLE_WIDTH * Mathf.Max(zk, 0.0f)) + POCKET_RADIUS * zw * Mathf.Abs(zk) + TABLE_HEIGHT) * zy; // Konstant
+
+            // Check if colliding
+            l = zw * zy;
+            if (A.z * l > (A.x * d + k) * l)
+            {
+                // Get line normal
+                N.x = zx * zk;
+                N.z = -zy;
+                N.y = 0.0f;
+                N *= zw * r;
+
+                // New position
+                i = (A.x * d + A.z - k) / (2.0f * d);
+                j = i * d + k;
+
+                ball_CO[id].x = i;
+                ball_CO[id].z = j;
+
+                // Reflect velocity
+                ApplyBounceCushion(id, N);
+            }
+        }
+        else // edges
+        {
+            if (A.x * zx > TABLE_WIDTH)
+            {
+                ball_CO[id].x = TABLE_WIDTH * zx;
+                ApplyBounceCushion(id, Vector3.left * zx);
+            }
+
+            if (A.z * zy > TABLE_HEIGHT)
+            {
+                ball_CO[id].z = TABLE_HEIGHT * zy;
+                ApplyBounceCushion(id, Vector3.back * zy);
+            }
+        }
+    }
+
+    // Advance simulation 1 step for ball id
+    private void AdvanceSimulationForBall(int id)
+    {
+        // Since v1.5.0
+        Vector3 V = ball_V[id];
+        Vector3 W = ball_W[id];
+        Vector3 cv;
+
+        // Equations derived from: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.89.4627&rep=rep1&type=pdf
+        // 
+        // R: Contact location with ball and floor aka: (0,-r,0)
+        // µₛ: Slipping friction coefficient
+        // µᵣ: Rolling friction coefficient
+        // i: Up vector aka: (0,1,0)
+        // g: Planet Earth's gravitation acceleration ( 9.80665 )
+        // 
+        // Relative contact velocity (marlow):
+        //   c = v + R✕ω
+        //
+        // Ball is classified as 'rolling' or 'slipping'. Rolling is when the relative velocity is none and the ball is
+        // said to be in pure rolling motion
+        //
+        // When ball is classified as rolling:
+        //   Δv = -µᵣ∙g∙Δt∙(v/|v|)
+        //
+        // Angular momentum can therefore be derived as:
+        //   ωₓ = -vᵤ/R
+        //   ωᵧ =  0
+        //   ωᵤ =  vₓ/R
+        //
+        // In the slipping state:
+        //   Δω = ((-5∙µₛ∙g)/(2/R))∙Δt∙i✕(c/|c|)
+        //   Δv = -µₛ∙g∙Δt(c/|c|)
+
+        // Relative contact velocity of ball and table
+        cv = V + Vector3.Cross(CONTACT_POINT, W);
+
+        // Rolling is achieved when cv's length is approaching 0
+        // The epsilon is quite high here because of the fairly large timestep we are working with
+        if (cv.magnitude <= 0.1f)
+        {
+            //V += -F_ROLL * GRAVITY * FIXED_TIME_STEP * V.normalized;
+            // (baked):
+            V += -0.00122583125f * V.normalized;
+
+            // Calculate rolling angular velocity
+            W.x = -V.z * BALL_1OR;
+            W.y = 0.0f;
+            W.z = V.x * BALL_1OR;
+
+            // Stopping scenario
+            if (V.magnitude < 0.01f && W.magnitude < 0.2f)
+            {
+                W = Vector3.zero;
+                V = Vector3.zero;
+            }
+            else
+            {
+                ballsMoving = true;
+            }
+        }
+        else // Slipping
+        {
+            Vector3 nv = cv.normalized;
+
+            // Angular slipping friction
+            //W += ((-5.0f * F_SLIDE * 9.8f)/(2.0f * 0.03f)) * FIXED_TIME_STEP * Vector3.Cross( Vector3.up, nv );
+            // (baked):
+            W += -2.04305208f * Vector3.Cross(Vector3.up, nv);
+            V += -F_SLIDE * 9.8f * FIXED_TIME_STEP * nv;
+
+            ballsMoving = true;
+        }
+
+        ball_W[id] = W;
+        ball_V[id] = V;
+        ballsToRender[id].transform.Rotate(W.normalized, W.magnitude * FIXED_TIME_STEP * -Mathf.Rad2Deg, Space.World);
+
+        uint ball_bit = 0x1U << id;
+
+        // ball/ball collisions
+        for (int i = id + 1; i < 16; i++)
+        {
+            ball_bit <<= 1;
+
+            if ((ball_bit & ballPocketedState) != 0U)
+                continue;
+
+            Vector3 delta = ball_CO[i] - ball_CO[id];
+            float dist = delta.magnitude;
+
+            if (dist < BALL_DIAMETRE)
+            {
+                // Physics shit
+
+                Vector3 normal = delta / dist;
+
+                Vector3 velocityDelta = ball_V[id] - ball_V[i];
+
+                float dot = Vector3.Dot(velocityDelta, normal);
+
+                if (dot > 0.0f)
+                {
+                    Vector3 reflection = normal * dot;
+                    ball_V[id] -= reflection;
+                    ball_V[i] += reflection;
+
+                    // Prevent sound spam if it happens
+                    if (ball_V[id].sqrMagnitude > 0 && ball_V[i].sqrMagnitude > 0)
+                    {
+                        int clip = UnityEngine.Random.Range(0, hitsSfx.Length - 1);
+                        float vol = Mathf.Clamp01(ball_V[id].magnitude * reflection.magnitude);
+                        ballPool[id].transform.position = ballsToRender[id].transform.position;
+                        ballPool[id].PlayOneShot(hitsSfx[clip], vol);
+                    }
+
+                    // First hit detected
+                    if (id == 0)
+                    {
+                        if (isGameModeTwo)
+                        {
+                            if (isKorean)  // KR 사구 ( Sagu )
+                            {
+                                if (i == 9)
+                                {
+                                    if (!isMadeFoul)
+                                    {
+                                        OnLocalCaromPenalize(ball_CO[i]);
+                                    }
+                                }
+                                else
+                                {
+                                    if (isFirstHit == 0)
+                                    {
+                                        isFirstHit = i;
+                                    }
+                                    else
+                                    {
+                                        if (i != isFirstHit)
+                                        {
+                                            if (isSecondHit == 0)
+                                            {
+                                                isSecondHit = i;
+                                                OnLocalCaromPoint(ball_CO[i]);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            else // JP 四つ玉 ( Yotsudama )
+                            {
+                                if (isFirstHit == 0)
+                                {
+                                    isFirstHit = i;
+                                }
+                                else
+                                {
+                                    if (isSecondHit == 0)
+                                    {
+                                        if (i != isFirstHit)
+                                        {
+                                            isSecondHit = i;
+                                            OnLocalCaromPoint(ball_CO[i]);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (isThirdHit == 0)
+                                        {
+                                            if (i != isFirstHit && i != isSecondHit)
+                                            {
+                                                isThirdHit = i;
+                                                OnLocalCaromPoint(ball_CO[i]);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (isFirstHit == 0)
+                            {
+                                isFirstHit = i;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ( Since v0.2.0a ) Check if we can predict a collision before move update happens to improve accuracy
+    private bool isCollisionPredictable()
+    {
+        // Get what will be the next position
+        Vector3 originalDelta = ball_V[0] * FIXED_TIME_STEP;
+        Vector3 norm = ball_V[0].normalized;
+
+        Vector3 h;
+        float lf, s, nmag;
+
+        // Closest found values
+        float minlf = 9999999.0f;
+        int minid = 0;
+        float mins = 0;
+
+        uint ball_bit = 0x1U;
+
+        // Loop balls look for collisions
+        for (int i = 1; i < 16; i++)
+        {
+            ball_bit <<= 1;
+
+            if ((ball_bit & ballPocketedState) != 0U)
+                continue;
+
+            h = ball_CO[i] - ball_CO[0];
+            lf = Vector3.Dot(norm, h);
+            s = BALL_DSQRPE - Vector3.Dot(h, h) + lf * lf;
+
+            if (s < 0.0f)
+                continue;
+
+            if (lf < minlf)
+            {
+                minlf = lf;
+                minid = i;
+                mins = s;
+            }
+        }
+
+        if (minid > 0)
+        {
+            nmag = minlf - Mathf.Sqrt(mins);
+
+            // Assign new position if got appropriate magnitude
+            if (nmag * nmag < originalDelta.sqrMagnitude)
+            {
+                ball_CO[0] += norm * nmag;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Run one physics iteration for all balls
+    private void AdvanceSimilationForAllBalls()
+    {
+        ballsMoving = false;
+
+        uint ball_bit = 0x1u;
+
+        // Cue angular velocity
+        if ((ballPocketedState & 0x1U) == 0)
+        {
+
+            if (!isCollisionPredictable())
+            {
+                // Apply movement
+                ball_CO[0] += ball_V[0] * FIXED_TIME_STEP;
+            }
+
+            AdvanceSimulationForBall(0);
+        }
+
+        // Run main simulation / inter-ball collision
+        for (int i = 1; i < 16; i++)
+        {
+            ball_bit <<= 1;
+
+            if ((ball_bit & ballPocketedState) == 0U)
+            {
+                ball_CO[i] += ball_V[i] * FIXED_TIME_STEP;
+
+                AdvanceSimulationForBall(i);
+            }
+        }
+
+        // Check if simulation has settled
+        if (!ballsMoving)
+        {
+            if (gameIsSimulating)
+            {
+                OnLocalSimulationEnd();
+            }
+
+            return;
+        }
+
+        if (isGameModeTwo)
+        {
+            BallTableCarom(0);
+            BallTableCarom(2);
+            BallTableCarom(3);
+            BallTableCarom(9);
+        }
+        else
+        {
+            ball_bit = 0x1U;
+
+            // Run edge collision
+            for (int i = 0; i < 16; i++)
+            {
+                if ((ball_bit & ballPocketedState) == 0U)
+                    HandleTableEdgeCollision(i);
+
+                ball_bit <<= 1;
+            }
+        }
+
+        if (isGameModeTwo) return;
+
+        ball_bit = 0x1U;
+
+        // Run triggers
+        for (int i = 0; i < 16; i++)
+        {
+            if ((ball_bit & ballPocketedState) == 0U)
+            {
+                CheckPockets(i);
+            }
+
+            ball_bit <<= 1;
+        }
+    }
+
+    // Ray circle intersection
+    // yes, its fixed size circle
+    // Output is dispensed into the below variable
+    // One intersection point only
+    // This is not used in physics calcuations, only cue input
+    private bool IsIntersectingWithCircle(Vector2 start, Vector2 dir, Vector2 circle)
+    {
+        Vector2 nrm = dir.normalized;
+        Vector2 h = circle - start;
+        float lf = Vector2.Dot(nrm, h);
+        float s = BALL_RSQR - Vector2.Dot(h, h) + lf * lf;
+
+        if (s < 0.0f) return false;
+
+        s = Mathf.Sqrt(s);
+
+        if (lf < s)
+        {
+            if (lf + s >= 0)
+            {
+                s = -s;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        rayCircleOutput = start + nrm * (lf - s);
+        return true;
+    }
+
+    private bool IsIntersectignWithSphere(Vector3 start, Vector3 dir, Vector3 sphere)
+    {
+        Vector3 nrm = dir.normalized;
+        Vector3 h = sphere - start;
+        float lf = Vector3.Dot(nrm, h);
+        float s = BALL_RSQR - Vector3.Dot(h, h) + lf * lf;
+
+        if (s < 0.0f) return false;
+
+        s = Mathf.Sqrt(s);
+
+        if (lf < s)
+        {
+            if (lf + s >= 0)
+            {
+                s = -s;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        raySphereOutput = start + nrm * (lf - s);
+        return true;
+    }
+
+    // Closest point on line from pos
+    private Vector2 GetClosestPointOnLineFromPos(Vector2 start, Vector2 dir, Vector2 pos)
+    {
+        return start + dir * Vector2.Dot(pos - start, dir);
+    }
+
+    // Find the lowest numbered ball, that isnt the cue, on the table
+    // This function finds the VISUALLY represented lowest ball,
+    // since 8 has id 1, the search needs to be split
+    private int GetLowestNumberedBall(uint field)
+    {
+        for (int i = 2; i <= 8; i++)
+        {
+            if (((field >> i) & 0x1U) == 0x00U)
+                return i;
+        }
+
+        if (((field) & 0x2U) == 0x00U)
+            return 1;
+
+        for (int i = 9; i < 16; i++)
+        {
+            if (((field >> i) & 0x1U) == 0x00U)
+                return i;
+        }
+
+        // ??
+        return 0;
+    }
+
+    private void OnTurnOverGameWon(uint winner)
+    {
+        isGameOver = true;
+        winnerID = winner;
+
+        PackNetworkData(turnID);
+        ReadNetworkData();
+
+        OnLocalGameOver();
+    }
+
+    private void OnTurnOverPassed()
+    {
+        isPlayerAllowedToPlay = true;
+
+        PackNetworkData(turnID ^ 0x1u);
+        ReadNetworkData();
+    }
+
+    private void OnTurnOverFoul()
+    {
+        isFoul = true;
+        isPlayerAllowedToPlay = true;
+
+        PackNetworkData(turnID ^ 0x1U);
+        ReadNetworkData();
+    }
+
+    private void OnTurnOverContinue()
+    {
+        // Close table if it was open ( 8 ball specific )
+        if (isGameModeZero)
+        {
+            if (isOpen)
+            {
+                uint sinorange = 0;
+                uint sinblue = 0;
+                uint pmask = ballPocketedState >> 2;
+
+                for (int i = 0; i < 7; i++)
+                {
+                    if ((pmask & 0x1u) == 0x1u)
+                        sinblue++;
+
+                    pmask >>= 1;
+                }
+                for (int i = 0; i < 7; i++)
+                {
+                    if ((pmask & 0x1u) == 0x1u)
+                        sinorange++;
+
+                    pmask >>= 1;
+                }
+
+                if (sinblue == sinorange)
+                {
+                    // Sunk equal amounts therefore still undecided
+                }
+                else
+                {
+                    if (sinblue > sinorange)
+                    {
+                        playerColours = turnID;
+                    }
+                    else
+                    {
+                        playerColours = turnID ^ 0x1u;
+                    }
+
+                    isOpen = false;
+                    OnLocalTableClosed();
+                }
+            }
+        }
+
+        // Keep playing
+        isPlayerAllowedToPlay = true;
+
+        PackNetworkData(turnID);
+        ReadNetworkData();
+    }
+
+    private Vector3 IntersectPlaneAndLine(Vector3 n, float d, Vector3 a, Vector3 b)
+    {
+        Vector3 ba = b - a;
+        float nDotA = Vector3.Dot(n, a);
+        float nDotBA = Vector3.Dot(n, ba);
+
+        return a + (((d - nDotA) / nDotBA) * ba);
+    }
+
+    // Setup meshes on gameobject
+    private void SetupMeshes(GameObject button, int variant, bool state)
+    {
+        button.GetComponent<MeshFilter>().sharedMesh = m_buttonmeshes[variant * 3 + (state ? 1 : 0)];
+    }
+
+    private void InitializeMenu()
+    {
+        // Setup button meshes
+        SetupMeshes(m_gamemode_buttons[0], EButtonMesh_8ball, gameMode == 0u);
+        SetupMeshes(m_gamemode_buttons[1], EButtonMesh_9ball, gameMode == 1u);
+        SetupMeshes(m_gamemode_buttons[2], EButtonMesh_4ball, gameMode == 2u);
+
+        SetupMeshes(m_join_buttons[0], EButtonMesh_join_0, false);
+        SetupMeshes(m_join_buttons[1], EButtonMesh_join_1, false);
+
+        //_htbtn_init( m_startbutton, EButtonMesh_play, false );
+
+        SetupMeshes(m_teambuttons[0], EButtonMesh_red, !isTeams);
+        SetupMeshes(m_teambuttons[1], EButtonMesh_green, isTeams);
+
+        SetupMeshes(m_timebuttons[0], EButtonMesh_triangle, true);
+        SetupMeshes(m_timebuttons[1], EButtonMesh_triangle, true);
+        SetupMeshes(m_newGameBtn, EButtonMesh_play, true);
+
+        m_outline_filter = m_gm_dkoutline.GetComponent<MeshFilter>();
+
+        // Create surface plane
+        m_planenormal = menuBase.transform.up;
+        m_planedist = Vector3.Dot(menuBase.transform.position, m_planenormal);
+
+        localplayer = Networking.LocalPlayer;
+
+        m_gm_dkoutline.SetActive(false);
+
+        isLobbyClosed = true;
+        ViewTimer();
+        ViewTeams();
+        ViewGameMode();
+        ViewMenu();
+    }
+
+    // View gamemode changes
+    private void ViewGameMode()
+    {
+        for (int i = 0; i < m_gamemode_buttons.Length; i++)
+        {
+            if (gameMode == (uint)i)
+            {
+                m_gamemode_buttons[i].GetComponent<MeshFilter>().sharedMesh = m_buttonmeshes[(EButtonMesh_8ball + i) * 3 + 1];
+            }
+            else
+            {
+                m_gamemode_buttons[i].GetComponent<MeshFilter>().sharedMesh = m_buttonmeshes[(EButtonMesh_8ball + i) * 3];
+            }
+        }
+    }
+
+    private void ViewJoin()
+    {
+        int playernum = 0;
+
+        if (!isLobbyClosed)
+        {
+            VRCPlayerApi host = Networking.GetOwner(m_playerslot_owners[0]);
+
+            // Check out player names
+            for (int i = 0; i < (isTeams ? 4 : 2); i++)
+            {
+                VRCPlayerApi player = Networking.GetOwner(m_playerslot_owners[i]);
+
+                // Mark host
+                if (i == 0)
+                {
+                    m_lobbyNames[i].text = "<color=\"#f2ecb8\">" + player.displayName + "</color>";
+                    playernum++;
+                }
+                else
+                {
+                    // Its us
+                    if (localPlayerID == i)
+                    {
+                        // Error: Local believes that we are in lobby, but someone else is there
+                        if (player.playerId != Networking.LocalPlayer.playerId)
+                        {
+#if HT8B_DEBUGGER
+                            _frp(FRP_ERR + "Error: de-sync local lobby status" + FRP_END);
+#endif
+
+                            localPlayerID = -1;
+                            m_lobbyNames[i].text = "<color=\"#ff0000\">ERROR</color>";
+                        }
+                        else
+                        {
+                            playernum++;
+                            m_lobbyNames[i].text = "<color=\"#cae4ed\">" + player.displayName + "</color>";
+                        }
+                    }
+                    else
+                    {
+                        // Player is joined
+                        if (host.playerId != player.playerId)
+                        {
+                            m_lobbyNames[i].text = "<color=\"#ffffff\">" + player.displayName + "</color>";
+                            playernum++;
+                        }
+                        else
+                        {
+                            m_lobbyNames[i].text = "";
+                        }
+                    }
+                }
+            }
+        }
+
+        isGameModePractice = localPlayerID == 0 && playernum == 1;
+
+        // If in the game
+        if (localPlayerID >= 0)
+        {
+            // Set our team button to the 'leave' button
+            SetupMeshes(m_join_buttons[localTeamID], EButtonMesh_join_0 + (int)localTeamID, true);
+
+            // Opposite button should become startgame/disabled, 'enabled' if player 0
+            if (localPlayerID == 0)
+            {
+                m_join_buttons[1].SetActive(true);
+                SetupMeshes(m_join_buttons[1], EButtonMesh_play, true);
+            }
+            else
+            {
+                m_join_buttons[localTeamID ^ 0x1u].SetActive(false);
+            }
+        }
+        else // Otherwise, its just join buttons
+        {
+            m_join_buttons[0].SetActive(true);
+            m_join_buttons[1].SetActive(true);
+            SetupMeshes(m_join_buttons[0], EButtonMesh_join_0, false);
+            SetupMeshes(m_join_buttons[1], EButtonMesh_join_1, false);
+        }
+    }
+
+    private void ViewTimer()
+    {
+        if (lastViewTimer != timerType)
+        {
+            mainSrc.PlayOneShot(spinSfx);
+            lastViewTimer = timerType;
+            isSoundSpinning = true;
+        }
+
+        m_TimeLimit_x_target = new Vector3(-0.128f * (float)timerType, 0.0f, 0.0f);
+    }
+
+    private void ViewTeams()
+    {
+        m_TeamCover_target_s = isTeams ? new Vector3(0, 1, 1) : new Vector3(1, 1, 1);
+        SetupMeshes(m_teambuttons[0], EButtonMesh_red, !isTeams);
+        SetupMeshes(m_teambuttons[1], EButtonMesh_green, isTeams);
+
+        ViewJoin();
+    }
+
+    private void ViewMenu()
+    {
+        if (isLobbyClosed)
+        {
+            m_menuLoc_swt = Vector3.one;
+        }
+        else
+        {
+            m_menuLoc_swt = Vector3.zero;
+        }
+    }
+
+    private bool OnButtonPressed(GameObject btn, int typeid)
+    {
+        // Set automatic id's 
+        m_auto_id++;
+        m_auto_btnobjs[m_auto_id] = btn;
+
+        Vector3 delta; Vector3 tmp_pos;
+        delta = btn.transform.localPosition - m_cursor;
+
+        if (Mathf.Abs(delta.x) < m_current_x && Mathf.Abs(delta.z) < m_current_y)
+        {
+            if (m_desktop)
+            {
+                // Visual transform
+                if (Input.GetButton("Fire1"))
+                {
+                    tmp_pos = btn.transform.localPosition;
+                    tmp_pos.y = 0.0f;
+                    btn.transform.localPosition = tmp_pos;
+                }
+
+                m_gm_dkoutline.SetActive(true);
+                m_gm_dkoutline.transform.localPosition = btn.transform.localPosition;
+                m_gm_dkoutline.transform.localRotation = btn.transform.localRotation;
+
+                m_outline_filter.sharedMesh = m_buttonmeshes[typeid * 3 + 2];
+
+                // Actuation
+                if (Input.GetButtonDown("Fire1"))
+                {
+                    ButtonPressed();
+                    return true;
+                }
+            }
+            else // VR
+            {
+                // Button range
+                if (m_cursor.y < mGmButtonA && m_cursor.y > -0.1f)
+                {
+                    // Update visual position
+                    tmp_pos = btn.transform.localPosition;
+                    tmp_pos.y = Mathf.Clamp(m_cursor.y, 0.0f, tmp_pos.y);
+                    btn.transform.localPosition = tmp_pos;
+
+                    m_auto_btnstate[m_auto_id] |= ButtonState_Pressing;
+
+                    if (m_cursor.y <= 0.0f) // Actuation
+                    {
+                        // Rising edge
+                        if (m_auto_btnstate[m_auto_id] == ButtonState_Pressing)
+                        {
+                            m_auto_btnstate[m_auto_id] |= ButtonState_Triggered;
+
+                            ButtonPressed();
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // Join lobby
+    private void JoinPlayer(int id)
+    {
+        localPlayerID = id;
+        localTeamID = ((uint)id & 0x2u) >> 1;
+        Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[id]);
+
+        ViewJoin();
+    }
+
+    // Join team locally
+    private void JoinTeam(int id)
+    {
+        // Leave routine
+        if (localPlayerID >= 0)
+        {
+            // Close lobby
+            if (localPlayerID == 0)
+            {
+                if (id == 0)
+                {
+#if HT8B_DEBUGGER
+                    _frp(FRP_ERR + "( closing lobby )" + FRP_END);
+#endif
+
+                    isLobbyClosed = true;
+                    localPlayerID = -1;
+
+                    ViewMenu();
+                    Networking.SetOwner(Networking.LocalPlayer, this.gameObject);
+                    PackNetworkDataLossily();
+                }
+                else
+                {
+#if HT8B_DEBUGGER
+                    _frp(FRP_YES + "Starting game!" + FRP_END);
+#endif
+
+                    isRegionSelected = false;
+                    StartNewGame();
+                    return;
+                }
+            }
+            else
+            {
+                if ((int)localTeamID == id)
+                {
+#if HT8B_DEBUGGER
+                    _frp(FRP_WARN + "( leaving lobby )" + FRP_END);
+#endif
+
+                    // Set owner back to host
+                    Networking.SetOwner(Networking.GetOwner(m_playerslot_owners[0]), m_playerslot_owners[localPlayerID]);
+
+                    // Mark locally out of game
+                    localPlayerID = -1;
+                }
+                else
+                {
+#if HT8B_DEBUGGER
+                    _frp(FRP_LOW + "this button does nothing" + FRP_END);
+#endif
+                }
+            }
+
+            ViewJoin();
+            return;
+        }
+
+        // Create new lobby
+        if (isLobbyClosed)
+        {
+#if HT8B_DEBUGGER
+            _frp(FRP_YES + "Creating lobby" + FRP_END);
+#endif
+
+            // Assign other players to us to signify not joined
+            Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[1]);
+            Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[2]);
+            Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[3]);
+
+            isLobbyClosed = false;
+
+            Networking.SetOwner(Networking.LocalPlayer, this.gameObject);
+            PackNetworkDataLossily();
+
+            JoinPlayer(0);
+            ViewMenu();
+            return;
+        }
+
+        VRCPlayerApi gameHost = Networking.GetOwner(m_playerslot_owners[0]);
+
+        // Check for open spot on team
+        // Team 1
+        if (id == 1)
+        {
+            if (Networking.GetOwner(m_playerslot_owners[1]).playerId == gameHost.playerId)
+            {
+                JoinPlayer(1);
+            }
+            else if (isTeams && (Networking.GetOwner(m_playerslot_owners[3]).playerId == gameHost.playerId))
+            {
+                JoinPlayer(3);
+            }
+            else
+            {
+#if HT8B_DEBUGGER
+                _frp(FRP_ERR + "no slot availible" + FRP_END);
+#endif
+            }
+        }
+
+        // Team 2
+        else if (isTeams && (Networking.GetOwner(m_playerslot_owners[2]).playerId == gameHost.playerId))
+        {
+            JoinPlayer(2);
+        }
+        else
+        {
+#if HT8B_DEBUGGER
+            _frp(FRP_ERR + "no slot availible" + FRP_END);
+#endif
+        }
+    }
+
+    private void ResetNetwork()
+    {
+        isLobbyClosed = true;
+
+        if (Networking.GetOwner(this.gameObject) == Networking.LocalPlayer)
+        {
+            Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[0]);
+            Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[1]);
+            Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[2]);
+            Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[3]);
+
+            PackNetworkDataLossily();
+        }
+    }
+
+    // Find button target
+    private void FindButtonTarget()
+    {
+        m_auto_id = -1;
+
+        GameObject btn;
+
+        // Join / Leave buttons
+        m_current_x = mGmButtonW;
+        m_current_y = mGmButtonH;
+
+        if (isLobbyClosed)
+        {
+            if (OnButtonPressed(m_newGameBtn, EButtonMesh_play))
+            {
+                JoinTeam(0);
+            }
+        }
+        else
+        {
+            for (int i = 0; i < m_join_buttons.Length; i++)
+            {
+                btn = m_join_buttons[i];
+
+                if (OnButtonPressed(btn, EButtonMesh_join_0 + i))
+                {
+                    JoinTeam(i);
+                }
+            }
+
+            if (localPlayerID == 0) // Host only
+            {
+                // Gamemode buttons
+                m_current_x = mGmButtonW;
+                m_current_y = mGmButtonH;
+
+                for (int i = 0; i < m_gamemode_buttons.Length; i++)
+                {
+                    btn = m_gamemode_buttons[i];
+
+                    if (OnButtonPressed(btn, EButtonMesh_8ball + i))
+                    {
+                        gameMode = (uint)i;
+                        ViewGameMode();
+                        PackNetworkDataLossily();
+                    }
+                }
+
+                // Smol buttons
+                m_current_x = mSmolButtonR;
+                m_current_y = mSmolButtonR;
+
+                // Timelimit buttons
+                if (OnButtonPressed(m_timebuttons[1], EButtonMesh_triangle))
+                {
+                    if (timerType > 0)
+                    {
+                        timerType--;
+
+                        ViewTimer();
+                        PackNetworkDataLossily();
+                    }
+                }
+                if (OnButtonPressed(m_timebuttons[0], EButtonMesh_triangle))
+                {
+                    if (timerType < 2)
+                    {
+                        timerType++;
+
+                        ViewTimer();
+                        PackNetworkDataLossily();
+                    }
+                }
+
+                // Teams enabled buttons
+                if (OnButtonPressed(m_teambuttons[0], EButtonMesh_red))
+                {
+                    isTeams = false;
+
+                    // Kick players
+                    Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[2]);
+                    Networking.SetOwner(Networking.LocalPlayer, m_playerslot_owners[3]);
+
+                    ViewTeams();
+                    PackNetworkDataLossily();
+                }
+                if (OnButtonPressed(m_teambuttons[1], EButtonMesh_green))
+                {
+                    isTeams = true;
+
+                    ViewTeams();
+                    PackNetworkDataLossily();
+                }
+            }
+        }
+    }
+
+    private void ButtonPressed()
+    {
+        mainSrc.PlayOneShot(buttonSfx);
+
+        if (menuHand != VRC_Pickup.PickupHand.None)
+        {
+            Networking.LocalPlayer.PlayHapticEventInHand(menuHand, 0.02f, 1.0f, 1.0f);
+        }
+    }
+
+    private void BeginMenu()
+    {
+        Vector3 tmp_pos;
+        GameObject btn;
+
+        for (int i = 0; i <= m_auto_id; i++)
+        {
+            if (m_auto_btnstate[i] == ButtonState_ShouldReset)
+            {
+                m_auto_btnstate[i] = ButtonState_None;
+            }
+
+            // Reset button Y position
+            btn = m_auto_btnobjs[i];
+            tmp_pos = btn.transform.localPosition;
+            tmp_pos.y = mGmButtonA;
+            btn.transform.localPosition = tmp_pos;
+
+            // Disables pressed so it can be re-set
+            m_auto_btnstate[i] &= ButtonState_FrameMask;
+        }
+    }
+
+    private void EnterMenu()
+    {
+        menuBase.SetActive(true);
+        ResetNetwork();
+
+        ViewTimer();
+        ViewTeams();
+        ViewGameMode();
+        ViewJoin();
+        ViewMenu();
+    }
+
+    private void ExitMenu()
+    {
+        isLobbyClosed = true;
+        menuBase.SetActive(false);
+    }
+
+    private void UpdateMenu()
+    {
+        if (localplayer == null) // Removed the ifdef because rider didn't like it, just return if local player is null, means we're in editor.
+            return;
+
+        m_desktop = !Networking.LocalPlayer.IsUserInVR();
+
+        if (Time.timeSinceLevelLoad > nextRefresh)
+        {
+            ViewJoin();
+            nextRefresh = Time.timeSinceLevelLoad + 0.5f;
+        }
+
+        // Desktop: Project cursor onto plane
+        if (m_desktop)
+        {
+            m_gm_dkoutline.SetActive(false);
+
+            VRCPlayerApi.TrackingData hmd = localplayer.GetTrackingData(VRCPlayerApi.TrackingDataType.Head);
+            m_cursor = IntersectPlaneAndLine(m_planenormal, m_planedist, hmd.position, hmd.position + (hmd.rotation * Vector3.forward));
+
+#if MENU_DEV
+            m_devcursor.transform.position = m_cursor;
+#endif
+
+            // Localize m_cursor
+            m_cursor = menuBase.transform.InverseTransformPoint(m_cursor);
+
+            menuHand = VRC_Pickup.PickupHand.None;
+            BeginMenu();
+            FindButtonTarget();
+        }
+        else
+        {
+#if MENU_DEV
+            m_devcursor.transform.position = localplayer.GetBonePosition(HumanBodyBones.RightIndexDistal);
+#endif
+
+            // Xiexe: Changed VR to use just the tracking data position, hopefully this feels alright.
+            BeginMenu();
+            menuHand = VRC_Pickup.PickupHand.Left;
+            VRCPlayerApi.TrackingData leftHand = localplayer.GetTrackingData(VRCPlayerApi.TrackingDataType.LeftHand);
+            m_cursor = menuBase.transform.InverseTransformPoint(leftHand.position);
+            FindButtonTarget();
+
+            menuHand = VRC_Pickup.PickupHand.Right;
+            VRCPlayerApi.TrackingData rightHand = localplayer.GetTrackingData(VRCPlayerApi.TrackingDataType.RightHand);
+            m_cursor = menuBase.transform.InverseTransformPoint(rightHand.position);
+            FindButtonTarget();
+        }
+
+        // Update visual stuff
+        m_TeamCover_current_s = Vector3.Lerp(m_TeamCover_current_s, m_TeamCover_target_s, Time.deltaTime * 5.0f);
+        m_TimeLimit_x_current = Vector3.Lerp(m_TimeLimit_x_current, m_TimeLimit_x_target, Time.deltaTime * 5.0f);
+        m_menuLoc_sw = Vector3.Lerp(m_menuLoc_sw, m_menuLoc_swt, Time.deltaTime * 5.0f);
+
+        // Stop sound
+        if (isSoundSpinning && Vector3.Distance(m_TimeLimit_x_current, m_TimeLimit_x_target) < 0.01f)
+        {
+            isSoundSpinning = false;
+            mainSrc.PlayOneShot(spinStopSfx);
+        }
+
+        m_TeamCover.transform.localScale = m_TeamCover_current_s;
+        m_TimeLimitDisp.transform.localPosition = m_TimeLimit_x_current;
+
+        // Menu locations scale swap
+        m_menuLoc_start.transform.localScale = m_menuLoc_sw;
+        m_menuLoc_main.transform.localScale = Vector3.one - m_menuLoc_sw;
+    }
+
+    // Copy current values to previous values, no memcpy here >:(
+    private void CopyCurrentValuesToPrevious()
+    {
+        // Init _prv states
+        oldTurnID = turnID;
+        oldOpen = isOpen;
+        oldGameOver = isGameOver;
+        oldGameID = gameID;
+
+        // Since 1.0.0
+        oldGameMode = gameMode;
+        oldTimer = timerType;
+        oldTeams = isTeams;
+        oldLobbyClosed = isLobbyClosed;
+
+        //sn_pocketed_prv = sn_pocketed;		this one needs to be independent 
+        //sn_simulating_prv = sn_simulating;
+        //sn_foul_prv = sn_foul;
+        //sn_playerxor_prv = sn_playerxor;
+        //sn_winnerid_prv = sn_winnerid;
+        //sn_permit_prv = sn_permit;
+    }
+
+    private void OnDesktopUIExit()
+    {
+        isDesktopShootUI = false;
+        desktopBase.SetActive(false);
+        gripControllers[0].desktopPrimaryControl = true;
+        gripControllers[1].desktopPrimaryControl = true;
+
+        Networking.LocalPlayer.SetWalkSpeed(2.0f);
+        Networking.LocalPlayer.SetRunSpeed(4.0f);
+        Networking.LocalPlayer.SetStrafeSpeed(2.0f);
+    }
+
+    private void AllowHit()
+    {
+        isTurnLocalLive = true;
+
+        // Reset hit point
+        desktopHitCursor = Vector3.zero;
+    }
+
+    private void DenyHit()
+    {
+        isTurnLocalLive = false;
+    }
+
+    private void UpdateDesktopUI()
+    {
+        if (isDesktopFrameIgnore)
+        {
+            isDesktopFrameIgnore = false;
+            return;
+        }
+
+        if (Input.GetKeyDown(KeyCode.E))
+        {
+            OnDesktopUIExit();
+            return;
+        }
+
+        // Keep UI rendering
+        VRCPlayerApi.TrackingData hmd = localplayer.GetTrackingData(VRCPlayerApi.TrackingDataType.Head);
+        desktopQuad.transform.position = hmd.position + hmd.rotation * Vector3.forward;
+        dE.transform.position = desktopQuad.transform.position;
+
+        deskTopCursor.x = Mathf.Clamp
+        (
+            deskTopCursor.x + Input.GetAxis("Mouse X") * desktopCursorSpeed,
+            -desktopClampX,
+             desktopClampX
+        );
+        deskTopCursor.z = Mathf.Clamp
+        (
+            deskTopCursor.z + Input.GetAxis("Mouse Y") * desktopCursorSpeed,
+            -desktopClampY,
+             desktopClampY
+        );
+
+        if (isTurnLocalLive)
+        {
+            Vector3 ncursor = deskTopCursor;
+            ncursor.y = 0.0f;
+            Vector3 delta = ncursor - ball_CO[0];
+            GameObject cue = desktopStickBases[turnID];
+
+            if (Input.GetButton("Fire1"))
+            {
+                if (!isDesktopShootingIn)
+                {
+                    isDesktopShootingIn = true;
+
+                    // Create shooting vector
+                    desktopShootVector = delta.normalized;
+
+                    // Project reference start point
+                    desktopShootReference = Vector3.Dot(desktopShootVector, ncursor);
+
+                    // Create copy of cursor for later
+                    desktopSafeRemovePoint = deskTopCursor;
+
+                    // Unlock cursor position from table
+                    desktopClampX = Mathf.Infinity;
+                    desktopClampY = Mathf.Infinity;
+                }
+
+                // Calculate shoot amount via projection
+                shootAmt = desktopShootReference - Vector3.Dot(desktopShootVector, ncursor);
+                isDesktopSafeRemove = shootAmt < 0.0f;
+
+                shootAmt = Mathf.Clamp(shootAmt, 0.0f, 0.5f);
+
+                // Set delta back to dkShootVector
+                delta = desktopShootVector;
+
+                // Disable cursor in shooting mode
+                desktopCursorObject.SetActive(false);
+            }
+            else
+            {
+                // Trigger shot
+                if (isDesktopShootingIn)
+                {
+                    // Shot cancel
+                    if (isDesktopSafeRemove)
+                    {
+
+                    }
+                    else // FIREEEEE 
+                    {
+                        // Fake hit ( kinda )
+                        float vel = Mathf.Pow(shootAmt * 2.0f, 1.4f) * 9.0f;
+
+                        ball_V[0] = desktopShootVector * vel;
+
+                        Vector3 r_1 = (raySphereOutput - ball_CO[0]) * BALL_1OR;
+                        Vector3 p = desktopShootVector.normalized * vel;
+                        ball_W[0] = Vector3.Cross(r_1, p) * -25.0f;
+
+#if HT8B_DEBUGGER
+                        _frp(FRP_WARN + "Angular velocity: " + ball_W[0].ToString() + ". Velocity: " + ball_V[0].ToString() + FRP_END);
+#endif
+
+                        cue.transform.localPosition = new Vector3(2000.0f, 2000.0f, 2000.0f);
+                        isTurnLocalLive = false;
+                        HitGenerically();
+                    }
+
+                    // Restore cursor position
+                    deskTopCursor = desktopSafeRemovePoint;
+                    desktopClampX = TABLE_WIDTH;
+                    desktopClampY = TABLE_HEIGHT;
+
+                    // 1-frame override to fix rotation
+                    delta = desktopShootVector;
+                }
+
+                isDesktopShootingIn = false;
+                shootAmt = 0.0f;
+                desktopCursorObject.SetActive(true);
+            }
+
+            if (Input.GetKey(KeyCode.W))
+            {
+                desktopHitCursor += Vector3.forward * Time.deltaTime;
+            }
+            if (Input.GetKey(KeyCode.S))
+            {
+                desktopHitCursor += Vector3.back * Time.deltaTime;
+            }
+            if (Input.GetKey(KeyCode.A))
+            {
+                desktopHitCursor += Vector3.left * Time.deltaTime;
+            }
+            if (Input.GetKey(KeyCode.D))
+            {
+                desktopHitCursor += Vector3.right * Time.deltaTime;
+            }
+
+            // Clamp in circle
+            if (desktopHitCursor.magnitude > 0.90f)
+            {
+                desktopHitCursor = desktopHitCursor.normalized * 0.9f;
+            }
+
+            desktopHitPosition.transform.localPosition = desktopHitCursor;
+
+            // Get angle
+            float ang = Mathf.Atan2(delta.x, delta.z);
+
+            // Create rotation
+            Quaternion xr = Quaternion.AngleAxis(10.0f, Vector3.right);
+            Quaternion r = Quaternion.AngleAxis(ang * Mathf.Rad2Deg, Vector3.up);
+
+            Vector3 worldHit = new Vector3(desktopHitCursor.x * BALL_PL_X, desktopHitCursor.z * BALL_PL_X, -0.89f - shootAmt);
+
+            cue.transform.localRotation = r * xr;
+            cue.transform.position = this.transform.TransformPoint(ball_CO[0] + (r * xr * worldHit));
+        }
+
+        desktopCursorObject.transform.localPosition = deskTopCursor;
+        desktopOverlayPower.transform.localScale = new Vector3(1.0f - (shootAmt * 2.0f), 1.0f, 1.0f);
+    }
+
+    private void HitGenerically()
+    {
+        // Make sure repositioner is turned off if the player decides he just
+        // wanted to hit it without putting it somewhere
+        isReposition = false;
+        marker.SetActive(false);
+        devhit.SetActive(false);
+        guideline.SetActive(false);
+
+        // Remove locks
+        EndHit();
+        isPlayerAllowedToPlay = false;
+        isFoul = false;    // In case did not drop foul marker
+
+        // Commit changes
+        gameIsSimulating = true;
+        oldPocketed = ballPocketedState;
+
+        // Make sure we definately are the network owner
+        Networking.SetOwner(Networking.LocalPlayer, this.gameObject);
+
+        PackNetworkData(turnID);
+        ReadNetworkData();
+
+        isSimulatedByUs = true;
+
+        float vol = Mathf.Clamp(ball_V[0].magnitude * 0.1f, 0f, 0.6f);
+        cueTipSrc.transform.position = cueTip.transform.position;
+        cueTipSrc.PlayOneShot(hitBallSfx, vol);
+    }
+
+    private void EncodeUint16(int pos, ushort v)
+    {
+        networkData[pos] = (byte)(v & 0xff);
+        networkData[pos + 1] = (byte)(((uint)v >> 8) & 0xff);
+    }
+
+    private ushort DecodeUint16(int pos)
+    {
+        return (ushort)(networkData[pos] | (((uint)networkData[pos + 1]) << 8));
+    }
+
+    // 4 char string from Vector2. Encodes floats in: [ -range, range ] to 0-65535
+    private void EncodeVector3(int pos, Vector3 vec, float range)
+    {
+        EncodeUint16(pos, (ushort)((vec.x / range) * I16_MAXf + I16_MAXf));
+        EncodeUint16(pos + 2, (ushort)((vec.z / range) * I16_MAXf + I16_MAXf));
+    }
+
+    // 6 char string from Vector3. Encodes floats in: [ -range, range ] to 0-65535
+    private void EncodeVector3Full(int pos, Vector3 vec, float range)
+    {
+        EncodeUint16(pos, (ushort)((Mathf.Clamp(vec.x, -range, range) / range) * I16_MAXf + I16_MAXf));
+        EncodeUint16(pos + 2, (ushort)((Mathf.Clamp(vec.y, -range, range) / range) * I16_MAXf + I16_MAXf));
+        EncodeUint16(pos + 4, (ushort)((Mathf.Clamp(vec.z, -range, range) / range) * I16_MAXf + I16_MAXf));
+    }
+
+    // Decode 4 chars at index to Vector3 (x,z). Decodes from 0-65535 to [ -range, range ]
+    private Vector3 DecodeVector3(int start, float range)
+    {
+        ushort _x = DecodeUint16(start);
+        ushort _y = DecodeUint16(start + 2);
+
+        float x = ((_x - I16_MAXf) / I16_MAXf) * range;
+        float y = ((_y - I16_MAXf) / I16_MAXf) * range;
+
+        return new Vector3(x, 0.0f, y);
+    }
+
+    // Decode 6 chars at index to Vector3. Decodes from 0-65535 to [ -range, range ]
+    private Vector3 DecodeVector3Full(int start, float range)
+    {
+        ushort _x = DecodeUint16(start);
+        ushort _y = DecodeUint16(start + 2);
+        ushort _z = DecodeUint16(start + 4);
+
+        float x = ((_x - I16_MAXf) / I16_MAXf) * range;
+        float y = ((_y - I16_MAXf) / I16_MAXf) * range;
+        float z = ((_z - I16_MAXf) / I16_MAXf) * range;
+
+        return new Vector3(x, y, z);
+    }
+
+    private string StringToHex()
+    {
+        string str = "";
+
+        for (int i = 0; i < networkData.Length; i += 2)
+        {
+            ushort v = DecodeUint16(i);
+            str += v.ToString("X4");
+        }
+
+        return str;
+    }
 }

--- a/us/ht8b_endgame.cs
+++ b/us/ht8b_endgame.cs
@@ -6,19 +6,20 @@ using VRC.Udon;
 
 public class ht8b_endgame : UdonSharpBehaviour
 {
-	[SerializeField] ht8b main;
-	void Interact()
-	{
-		EndGame();
-	}
+    public ht8b gameStateManager;
 
-	public void OnButtonPressed()
-	{
-		EndGame();
-	}
+    public override void Interact()
+    {
+        EndGame();
+    }
 
-	void EndGame()
-	{
-		main._tr_force_end();
-	}
+    public void OnButtonPressed()
+    {
+        EndGame();
+    }
+
+    private void EndGame()
+    {
+        gameStateManager.ForceReset();
+    }
 }

--- a/us/ht8b_menu.cs
+++ b/us/ht8b_menu.cs
@@ -15,358 +15,438 @@ using VRC.SDKBase;
 using VRC.Udon;
 using System;
 
-public class ht8b_menu : UdonSharpBehaviour{
+public class ht8b_menu : UdonSharpBehaviour
+{
+    private const float COLOUR_TRANSITION = 0.1f;
+    private const float COLOUR_TRANS_RECIP = 10.0f;
 
-const string FRP_LOW =  "<color=\"#ADADAD\">";
-const string FRP_ERR =  "<color=\"#B84139\">";
-const string FRP_WARN = "<color=\"#DEC521\">";
-const string FRP_YES =  "<color=\"#69D128\">";
-const string FRP_END =  "</color>";
+    // Networking msg id shite
+    private const byte sevenBallJoin = 0x00;
+    private const byte sevenBallLeave = 0x10;
+    private const byte sevenBallNewJoinPlayer = 0x20;  // Special new-joiner event to catch up quicker
 
-// UI materials
-[SerializeField] Material mat_high;
-[SerializeField] Material mat_low;
+    private const byte sevenBallMenuLocation = 0x30;
+    private const byte sevenBallCol = 0x40;
+    private const byte sevenBallGameMode = 0x50;
+    private const byte sevenBallTimeLimit = 0x60;
+    private const byte sevenBallTeams = 0x70;
 
-// UI element objects
-[SerializeField] GameObject loc_main;
+    // UI materials
+    public Material high;
+    public Material low;
 
-[SerializeField] MeshRenderer[]  ui_gamemodes;
-[SerializeField] MeshRenderer[]  ui_timelimits;
-[SerializeField] MeshRenderer[]  ui_joinbuttons;
-[SerializeField] MeshRenderer    ui_start;
-[SerializeField] GameObject      ui_newGame;
-[SerializeField] GameObject[]    ui_colour_selecters;
-[SerializeField] MeshRenderer[]  ui_teambuttons;
-[SerializeField] Text[]          ui_textplayers;
-[SerializeField] BoxCollider[]   lobby_owner_only;
+    // UI element objects
+    public GameObject mainLocation;
 
-// Networking stuff
-[SerializeField] GameObject[]    gm_tokens;
-[SerializeField] ht8b            main;
+    public MeshRenderer[] gameModes;
+    public MeshRenderer[] timeLimits;
+    public MeshRenderer[] joinButtons;
+    public MeshRenderer start;
+    private BoxCollider startCollider;
+    public GameObject newGame;
+    public GameObject[] colourSelectors;
+    public MeshRenderer[] teamButtons;
+    public Text[] textPlayers;
+    public BoxCollider[] lobbyOwnersOnly;
 
-// Visual
-[SerializeField] SkinnedMeshRenderer mr_sand_timer;
+    // Networking stuff
+    public GameObject[] tokens;
+    public ht8b gameStateManager;
 
-// Localize from ht8b.cs
-Texture[]      ball_textures;
-GameObject[]   ball_renderers;
-Material       ball_material;
-Material       table_material;
-GameObject     scorecard;
+    // Visual
+    public SkinnedMeshRenderer sandTimer;
 
-// Networked
-[HideInInspector] public uint gamemode_id;
-[HideInInspector] public uint colour_id;
-[HideInInspector] public uint timer_id;
-[HideInInspector] public uint teams_allowed;
+    // Localize from ht8b.cs
+    private Texture[] ballTextures;
+    private GameObject[] ballRenderers;
+    private Material ballMat;
+    private Material tableMat;
+    private GameObject scoreCard;
 
-// Non-critical
-uint menu_loc;    // 0: NewGame button, 1: Main menu
+    // Networked
+    [HideInInspector]
+    public uint gameModeID;
+    [HideInInspector]
+    public uint colourID;
+    [HideInInspector]
+    public uint timerID;
+    [HideInInspector]
+    public uint teamsAllowed;
 
-[HideInInspector] public bool game_is_running = false;
+    // Non-critical
+    private uint menuLocation; // 0: NewGame button, 1: Main menu
+
+    [HideInInspector]
+    public bool isGameRunning = false;
 
 #if USE_AUTH_LOBBY
+    private VRCPlayerApi[] playerAPIs = new VRCPlayerApi[4];
+    private bool[] playersReadyStatus = new bool[4];
 
-VRCPlayerApi[] player_apis = new VRCPlayerApi[4];
-bool[] player_ready        = new bool[4];
-
-// 
-int local_playerid = -1;      // -1: not joined, 0-3: joined as ID
-
+    private int localPlayerID = -1;      // -1: not joined, 0-3: joined as ID
 #endif
 
-Vector3[] reset_positions = new Vector3[ 16 ];
+    private Vector3[] resetPositions = new Vector3[16];
 
-// Reset to fully defined state
-public void _internal_state_reset()
-{
-   gamemode_id = 0u;
-   colour_id = 0;
-   timer_id = 0;
-   teams_allowed = 0;
-   menu_loc = 0;              // TODO: This should be 0
-   game_is_running = false;
-   
-   #if USE_AUTH_LOBBY
+    public Color grayFabric = new Color(0.3f, 0.3f, 0.3f, 1.0f);
+    public Color redFabric = new Color(0.8962264f, 0.2081864f, 0.1310519f);
+    public Color blueFabric = new Color(0.1f, 0.6f, 1.0f, 1.0f);
+    public Color whiteFabric = new Color(0.8f, 0.8f, 0.8f, 1.0f);
 
-   local_playerid = -1;
+    public Color blackLightColour = new Color(0.01f, 0.01f, 0.01f, 1.0f);
 
-   for( int i = 0; i < 4; i ++ )
-   {
-      player_ready[ i ] = false;
-      player_apis[ i ] = Networking.GetOwner( gm_tokens[ i ] );
-   }
+    [HideInInspector] public Color tableSource;   // Cloth color
+    private Color tableCurrent;
+    [HideInInspector] public Color tableSourceLight;    // Light color
+    private Color tableColourLight;
 
-   #endif
+    // VFX stuff
 
-   _menu_view();
-}
+    private float colourChangeTimer = 9.0f;
 
-Color k_fabricColour_gray = new Color( 0.3f, 0.3f, 0.3f, 1.0f );
-Color k_fabricColour_red = new Color( 0.8962264f, 0.2081864f, 0.1310519f );
-Color k_fabricColour_blue = new Color( 0.1f, 0.6f, 1.0f, 1.0f );
-Color k_fabricColour_white = new Color( 0.8f, 0.8f, 0.8f, 1.0f );
+    private bool isTransitioned = false;
+    private float sandTimerTargetWeight = 0.0f;
+    private float sandTimerWeight = 0.0f;
 
-Color k_lightColour_black = new Color( 0.01f, 0.01f, 0.01f, 1.0f );
+    public bool isInGame = false;
+    public bool isLobbyLeader = false;
 
-[HideInInspector] public Color table_src_colour;   // Cloth color
-Color table_current_colour;
-[HideInInspector] public Color table_src_light;    // Light color
-Color table_light_colour;
+    private uint maxColour = 2u;
 
-// VFX stuff
+    private float lastCheck = 0.0f;
 
-float colourchange_timer = 9.0f;
-const float k_COLOUR_TRANSITION = 0.1f;
-const float k_COLOUR_TRANS_RECIP = 10.0f;
+    [HideInInspector]
+    public int joinAsID = 0;
 
-bool has_transitioned = false;
+    // Change menu location button
+    [HideInInspector]
+    public uint inMenuLocation = 0;
 
-float sand_timer_target_weight = 0.0f;
-float sand_timer_weight = 0.0f;
+    [HideInInspector]
+    public int colourChangeDir = 0;
 
-public bool is_in_game = false;
-public bool is_lobby_leader = false;
+    [HideInInspector]
+    public int allowTeams = 0;
 
-// Networking msg id shite
-const byte k_7b_join = 0x00;
-const byte k_7b_leave = 0x10;
-const byte k_7b_nj_players = 0x20;  // Special new-joiner event to catch up quicker
+    [HideInInspector]
+    public int timeLimitID = 0;
 
-const byte k_7b_menu_loc = 0x30;
-const byte k_7b_ball_col = 0x40;
-const byte k_7b_gamemode = 0x50;
-const byte k_7b_timelimit = 0x60;
-const byte k_7b_teams = 0x70;
+    [HideInInspector]
+    public int inputGameModeID = 0;
 
-uint _colour_max = 2u;
+    public void Start()
+    {
+        startCollider = start.GetComponent<BoxCollider>();
+        if (!startCollider)
+        {
+            Debug.LogError("ht8b_menu: Start: start object has no box collider - aborting");
+            gameObject.SetActive(false);
+        }
 
+        // getting inspector variables from ht8b.cs
+        ballTextures = gameStateManager.sets;
+        ballRenderers = gameStateManager.ballsToRender;
+        ballMat = gameStateManager.ballMaterial;
+        tableMat = gameStateManager.tableMaterial;
+        scoreCard = gameStateManager.scoreCardRenderer.gameObject;
+
+        for (int i = 0; i < 16; i++)
+        {
+            resetPositions[i] = ballRenderers[i].transform.position;
+        }
+
+        // Initialize visual state to match internal
+        ResetInternalState();
+    }
+
+    public void Update()
+    {
 #if USE_AUTH_LOBBY
-public void _team_view()
-{
-   _frp( FRP_LOW + "_team_view()" + FRP_END );
-
-   if( teams_allowed == 0 )
-   {
-      ui_joinbuttons[ 2 ].gameObject.SetActive( false );
-      ui_joinbuttons[ 3 ].gameObject.SetActive( false );
-
-      ui_teambuttons[ 0 ].sharedMaterial = mat_low;
-      ui_teambuttons[ 1 ].sharedMaterial = mat_high;
-   }
-   else
-   {
-      ui_joinbuttons[ 2 ].gameObject.SetActive( true );
-      ui_joinbuttons[ 3 ].gameObject.SetActive( true );
-
-      ui_teambuttons[ 0 ].sharedMaterial = mat_high;
-      ui_teambuttons[ 1 ].sharedMaterial = mat_low;
-   }
-}
+        if (Time.timeSinceLevelLoad > lastCheck + 1.5f)
+        {
+            lastCheck = Time.timeSinceLevelLoad;
+            RefreshLobby();
+        }
 #endif
 
-public void _menu_view()
-{
-   _frp( FRP_LOW + "_menu_view()" + FRP_END );
+        if (colourChangeTimer <= COLOUR_TRANSITION)
+        {
+            colourChangeTimer -= Time.deltaTime;
 
-   if( menu_loc == 0 )
-   {
-      ui_newGame.SetActive( true );
-      loc_main.SetActive( false );
-   }
-   else
-   {
-      scorecard.SetActive( false );
-      ui_newGame.SetActive( false );
-      loc_main.SetActive( true );
-
-      //table_material.SetColor( "_EmissionColour", k_lightColour_black );
-      table_src_light = k_lightColour_black;
-
-      // Run view states when we load this menu
-      _colours_view();
-      _gamemode_view();
-      _timelimit_view();
-
-      #if USE_AUTH_LOBBY
-
-      _team_view();
-      _players_view();
-
-      // Add controls for lobby master
-      if( local_playerid == 0 )
-      {
-         for( int i = 0; i < lobby_owner_only.Length; i ++ )
-         {
-            lobby_owner_only[ i ].enabled = true;
-         }
-      }
-      else // Or not
-      {
-         for( int i = 0; i < lobby_owner_only.Length; i ++ )
-         {
-            lobby_owner_only[ i ].enabled = false;
-         }
-      }
-
-      for( int i = 0; i < 16; i ++ )
-      {
-         ball_renderers[ i ].transform.position = reset_positions[ i ];
-      }
-
-      #endif
-   }
-}
-
-void _colours_view()
-{
-   _frp( FRP_LOW + "_colours_view()" + FRP_END );
-
-   if( colourchange_timer > k_COLOUR_TRANSITION )
-   {
-      colourchange_timer = k_COLOUR_TRANSITION;
-   }
-
-   if( colourchange_timer < 0.0f )
-   {
-      colourchange_timer = -colourchange_timer;
-   }
-
-   has_transitioned = false;
-}
-
-void _gamemode_view()
-{
-   _frp( FRP_LOW + "_gamemode_view()" + FRP_END );
-
-   for( uint i = 0; i < ui_gamemodes.Length; i ++ )
-   {
-      if( i == gamemode_id )
-      {
-         ui_gamemodes[ i ].sharedMaterial = mat_high; 
-      }
-      else
-      {
-         ui_gamemodes[ i ].sharedMaterial = mat_low;
-      }
-   }
-
-   bool view_colour_selecters = true;
-
-   if( gamemode_id == 1u ) // 9 ball
-   {
-      table_src_colour = k_fabricColour_blue;
-
-      view_colour_selecters = false;
-   }
-   else // 8 ball derivatives
-   {
-      table_src_colour = k_fabricColour_gray;
-   }
-
-   if( gamemode_id == 2u )
-   {
-      _colour_max = 3u;
-   }
-   else
-   {
-      _colour_max = 2u;
-   }
-
-   ui_colour_selecters[ 0 ].SetActive( view_colour_selecters );
-   ui_colour_selecters[ 1 ].SetActive( view_colour_selecters );
-}
-
-public void _timelimit_view()
-{
-   _frp( FRP_LOW + "_timelimit_view()" + FRP_END );
-
-   for( int i = 0; i < ui_timelimits.Length; i ++ )
-   {
-      if( i == timer_id )
-      {
-         ui_timelimits[ i ].sharedMaterial = mat_high;
-      }
-      else
-      {
-         ui_timelimits[ i ].sharedMaterial = mat_low;
-      }
-   }
-
-   // TODO: Sandtimer vars
-   
-   if( timer_id == 0 )
-   {
-      mr_sand_timer.enabled = false;
-   }
-   else
-   {
-      mr_sand_timer.enabled = true;
-
-      if( timer_id == 1 )
-      {
-         sand_timer_target_weight = 50.0f;
-      }
-      else
-      {
-         sand_timer_target_weight = 0.0f;
-      }
-   }
-}
-
-#if USE_AUTH_LOBBY
-void _players_view()
-{
-   // _frp( FRP_LOW + "_players_view()" + FRP_END );
-
-   if( is_in_game )
-   {
-      _frp( FRP_ERR + "Menu was alive while game running for some reason... Disappearing" + FRP_END );
-      this.gameObject.SetActive( false );
-      return;
-   }
-
-   // Take most updated data
-   _api_users_refresh();
-
-   // Constantly internalize local state into ht8b.cs to make sure we can allow us to play
-   // when system control is handed over to it
-   main.local_playerid = local_playerid;
-
-   ui_textplayers[ 0 ].text = "";
-   ui_textplayers[ 1 ].text = "";
-
-   uint readied_players = 0;
-
-   // Texts for who is playing
-   for( uint i = 0; i < (teams_allowed == 1? 4: 2); i ++ )
-   {
-      if( player_ready[ i ] )
-      {
-#if UNITY_EDITOR
-         if( (i & 0x1U) == 1 )
-         {
-            ui_textplayers[ 1 ].text += "<UNITY_EDITOR>\n";
-
-            readied_players |= 0x2u;
-         }
-         else
-         {
-            ui_textplayers[ 0 ].text = "\n<UNITY_EDITOR>" + ui_textplayers[ 0 ].text;
-
-            readied_players |= 0x1u;
-         }
-#else
-         string dispname = player_apis[ i ].displayName;
-
-         if( i == local_playerid )
-         {
-
-            // Check for value stomping
-            if( player_apis[ i ] != Networking.LocalPlayer )
+            if (colourChangeTimer < 0.0f)
             {
-               _frp( FRP_ERR + "Local player value was stomped by a rogue network event" + FRP_END );
-               local_playerid = -1; 
+                if (!isTransitioned)
+                {
+                    ApexTransition();
+                    isTransitioned = true;
+                }
+            }
+
+            float scaling = Mathf.Abs(colourChangeTimer) * COLOUR_TRANS_RECIP;
+
+            if (colourChangeTimer < -COLOUR_TRANSITION)
+            {
+                colourChangeTimer = 9.0f;
+                scaling = 1.0f;
+            }
+
+            for (int i = 0; i < 16; i++)
+            {
+                ballRenderers[i].transform.localScale = new Vector3(scaling, scaling, scaling);
+            }
+        }
+
+        if (menuLocation == 0)
+        {
+            tableColourLight = tableSourceLight * (Mathf.Sin(Time.timeSinceLevelLoad * 3.0f) * 0.5f + 1.0f);
+        }
+        else
+        {
+            tableColourLight = Color.Lerp(tableColourLight, tableSourceLight, Time.deltaTime * 5.0f);
+            tableCurrent = Color.Lerp(tableCurrent, tableSource, Time.deltaTime * 5.0f);
+            tableMat.SetColor("_ClothColour", tableCurrent);
+        }
+
+        tableMat.SetColor("_EmissionColour", new Color(tableColourLight.r, tableColourLight.g, tableColourLight.b, 0.0f));
+
+        sandTimerWeight = Mathf.Lerp(sandTimerWeight, sandTimerTargetWeight, Time.deltaTime * 5.0f);
+        sandTimer.SetBlendShapeWeight(0, sandTimerWeight);
+    }
+
+    public void ViewTimeLimit()
+    {
+        for (int i = 0; i < timeLimits.Length; i++)
+        {
+            if (i == timerID)
+            {
+                timeLimits[i].sharedMaterial = high;
+            }
+            else
+            {
+                timeLimits[i].sharedMaterial = low;
+            }
+        }
+
+        // TODO: Sandtimer vars
+
+        if (timerID == 0)
+        {
+            sandTimer.enabled = false;
+        }
+        else
+        {
+            sandTimer.enabled = true;
+
+            if (timerID == 1)
+            {
+                sandTimerTargetWeight = 50.0f;
+            }
+            else
+            {
+                sandTimerTargetWeight = 0.0f;
+            }
+        }
+    }
+
+    public void ViewMenu()
+    {
+        if (menuLocation == 0)
+        {
+            newGame.SetActive(true);
+            mainLocation.SetActive(false);
+        }
+        else
+        {
+            scoreCard.SetActive(false);
+            newGame.SetActive(false);
+            mainLocation.SetActive(true);
+
+            //table_material.SetColor( "_EmissionColour", k_lightColour_black );
+            tableSourceLight = blackLightColour;
+
+            // Run view states when we load this menu
+            ViewColours();
+            ViewGameMode();
+            ViewTimeLimit();
+
+#if USE_AUTH_LOBBY
+            ViewTeam();
+            ViewPlayers();
+
+            // Add controls for lobby master
+            if (localPlayerID == 0)
+            {
+                for (int i = 0; i < lobbyOwnersOnly.Length; i++)
+                {
+                    lobbyOwnersOnly[i].enabled = true;
+                }
+            }
+            else
+            {
+                for (int i = 0; i < lobbyOwnersOnly.Length; i++)
+                {
+                    lobbyOwnersOnly[i].enabled = false;
+                }
+            }
+
+            for (int i = 0; i < 16; i++)
+            {
+                ballRenderers[i].transform.position = resetPositions[i];
+            }
+#endif
+        }
+    }
+
+    // Reset to fully defined state
+    public void ResetInternalState()
+    {
+        gameModeID = 0u;
+        colourID = 0;
+        timerID = 0;
+        teamsAllowed = 0;
+        menuLocation = 0;
+        isGameRunning = false;
+
+#if USE_AUTH_LOBBY
+        localPlayerID = -1;
+
+        for (int i = 0; i < 4; i++)
+        {
+            playersReadyStatus[i] = false;
+            playerAPIs[i] = Networking.GetOwner(tokens[i]);
+        }
+#endif
+
+        ViewMenu();
+    }
+
+#if USE_AUTH_LOBBY
+    public void ViewTeam()
+    {
+        if (teamsAllowed == 0)
+        {
+            joinButtons[2].gameObject.SetActive(false);
+            joinButtons[3].gameObject.SetActive(false);
+
+            teamButtons[0].sharedMaterial = low;
+            teamButtons[1].sharedMaterial = high;
+        }
+        else
+        {
+            joinButtons[2].gameObject.SetActive(true);
+            joinButtons[3].gameObject.SetActive(true);
+
+            teamButtons[0].sharedMaterial = high;
+            teamButtons[1].sharedMaterial = low;
+        }
+    }
+#endif
+
+
+    private void ViewColours()
+    {
+        if (colourChangeTimer > COLOUR_TRANSITION)
+        {
+            colourChangeTimer = COLOUR_TRANSITION;
+        }
+
+        if (colourChangeTimer < 0.0f)
+        {
+            colourChangeTimer = -colourChangeTimer;
+        }
+
+        isTransitioned = false;
+    }
+
+    private void ViewGameMode()
+    {
+        for (uint i = 0; i < gameModes.Length; i++)
+        {
+            if (i == gameModeID)
+            {
+                gameModes[i].sharedMaterial = high;
+            }
+            else
+            {
+                gameModes[i].sharedMaterial = low;
+            }
+        }
+
+        bool isViewColourSelectors = true;
+
+        if (gameModeID == 1u) // 9 ball
+        {
+            tableSource = blueFabric;
+            isViewColourSelectors = false;
+        }
+        else // 8 ball derivatives
+        {
+            tableSource = grayFabric;
+        }
+
+        if (gameModeID == 2u)
+        {
+            maxColour = 3u;
+        }
+        else
+        {
+            maxColour = 2u;
+        }
+
+        colourSelectors[0].SetActive(isViewColourSelectors);
+        colourSelectors[1].SetActive(isViewColourSelectors);
+    }
+
+
+
+#if USE_AUTH_LOBBY // TODO: This is a massive ifdef. Figure out what USE_AUTH_LOBBY does and refactor it away.
+    void ViewPlayers()
+    {
+        if (isInGame)
+        {
+            this.gameObject.SetActive(false);
+            return;
+        }
+
+        // Take most updated data
+        RefreshUsersAPI();
+
+        // Constantly internalize local state into ht8b.cs to make sure we can allow us to play
+        // when system control is handed over to it
+        gameStateManager.localPlayerID = localPlayerID;
+
+        textPlayers[0].text = "";
+        textPlayers[1].text = "";
+
+        uint readiedPlayers = 0;
+
+        // Texts for who is playing
+        for (uint i = 0; i < (teamsAllowed == 1 ? 4 : 2); i++)
+        {
+            if (playersReadyStatus[i])
+            {
+#if UNITY_EDITOR
+                if ((i & 0x1U) == 1)
+                {
+                    textPlayers[1].text += "<UNITY_EDITOR>\n";
+
+                    readiedPlayers |= 0x2u;
+                }
+                else
+                {
+                    textPlayers[0].text = "\n<UNITY_EDITOR>" + textPlayers[0].text;
+
+                    readiedPlayers |= 0x1u;
+                }
+#else
+         string dispname = player_apis[i].displayName;
+
+         if( i == localPlayerID )
+         {
+            // Check for value stomping
+            if( playerAPIs[i] != Networking.LocalPlayer )
+            {
+               localPlayerID = -1; 
                return;
             }
 
@@ -374,749 +454,637 @@ void _players_view()
             dispname = "<i>" + dispname + "</i>";
          }
 
-         if( (i & 0x1U) == 1 )
+         if((i & 0x1U) == 1)
          {
-            ui_textplayers[ 1 ].text += dispname + "\n";
-
-            readied_players |= 0x2;
+            textPlayers[1].text += dispname + "\n";
+            readiedPlayers |= 0x2;
          }
          else
          {
-            ui_textplayers[ 0 ].text = "\n" + dispname + ui_textplayers[ 0 ].text;
+            textPlayers[0].text = "\n" + dispname + textPlayers[0].text;
 
-            readied_players |= 0x1;
+            readiedPlayers |= 0x1;
          }
 #endif
-      }
+            }
 
-      // Update join buttons
-      if( local_playerid >= 0 )
-      {
-         if( i == (uint)local_playerid )
-         {
-            ui_joinbuttons[ i ].gameObject.SetActive( true );
-            ui_joinbuttons[ i ].sharedMaterial = mat_low;
-         }
-         else
-         {
-            ui_joinbuttons[ i ].gameObject.SetActive( false );
-         }
-      }
-      else
-      {
-         if( player_ready[ i ] )
-         {
-            ui_joinbuttons[ i ].gameObject.SetActive( false );
-         }
-         else
-         {
-            ui_joinbuttons[ i ].gameObject.SetActive( true );
-            ui_joinbuttons[ i ].sharedMaterial = mat_high;
-         }
-      }
-   }
+            // Update join buttons
+            if (localPlayerID >= 0)
+            {
+                if (i == (uint)localPlayerID)
+                {
+                    joinButtons[i].gameObject.SetActive(true);
+                    joinButtons[i].sharedMaterial = low;
+                }
+                else
+                {
+                    joinButtons[i].gameObject.SetActive(false);
+                }
+            }
+            else
+            {
+                if (playersReadyStatus[i])
+                {
+                    joinButtons[i].gameObject.SetActive(false);
+                }
+                else
+                {
+                    joinButtons[i].gameObject.SetActive(true);
+                    joinButtons[i].sharedMaterial = high;
+                }
+            }
+        }
 
-   if( (readied_players == 0x3u || gamemode_id == 2u) && local_playerid == 0 )
-   {
-      ui_start.sharedMaterial = mat_high;
-      ui_start.GetComponent<BoxCollider>().enabled = true;
-   }
-   else
-   {
-      ui_start.sharedMaterial = mat_low;
-      ui_start.GetComponent<BoxCollider>().enabled = false;
-   }
-}
+        if ((readiedPlayers == 0x3u || gameModeID == 2u) && localPlayerID == 0)
+        {
+            start.sharedMaterial = high;
+            startCollider.enabled = true;
+        }
+        else
+        {
+            start.sharedMaterial = low;
+            startCollider.enabled = false;
+        }
+    }
 
-void OnPlayerLeft( VRCPlayerApi player )
-{
-   // Lobby leader left so force a reset
+    public override void OnPlayerLeft(VRCPlayerApi player) // TODO: Free these two subscriptions from this ifdef block.
+    {
+        // Lobby leader left so force a reset
 
-   if( player == player_apis[ 0 ] )
-   {
-      _internal_state_reset();
-   }
-}
+        if (player == playerAPIs[0])
+        {
+            ResetInternalState();
+        }
+    }
 
-void OnPlayerJoined( VRCPlayerApi player )
-{
-   if( player == Networking.LocalPlayer )
-      return;
+    public override void OnPlayerJoined(VRCPlayerApi player)
+    {
+        if (player == Networking.LocalPlayer)
+            return;
 
-   if( local_playerid == 0 )
-   {
-      // Send newjoiner update
-      uint data = 0x00U;
+        if (localPlayerID == 0)
+        {
+            // Send newjoiner update
+            uint data = 0x00U;
 
-      // Compress players arr
-      for( int i = 0; i < 4; i ++ )
-      {
-         if( player_ready[ i ] )
-            data |= 0x1U << i;
-      }
+            // Compress players arr
+            for (int i = 0; i < 4; i++)
+            {
+                if (playersReadyStatus[i])
+                    data |= 0x1U << i;
+            }
 
-      // Send which player IDs is joined
-      _b7_send( (byte)(k_7b_nj_players | data) );
+            // Send which player IDs is joined
+            Send((byte)(sevenBallNewJoinPlayer | data));
 
-      // Send all the other states they need to catch up on
-      _b7_send( (byte)( k_7b_menu_loc | menu_loc ) );
-      _b7_send( (byte)( k_7b_ball_col | colour_id ) );
-      _b7_send( (byte)( k_7b_teams | teams_allowed ) );
-      _b7_send( (byte)( k_7b_timelimit | timer_id ) );
-      _b7_send( (byte)( k_7b_gamemode | gamemode_id ) );
-   }
-}
-
-#endif
-
-#if USE_KING_LOBBY
-
-void OnPlayerJoined( VRCPlayerApi player )
-{
-   // Ignore this if we are the one joining
-   if( player == Networking.LocalPlayer )
-      return;
-
-   if( Networking.GetOwner( main.gameObject ) == Networking.LocalPlayer )
-   {
-      FRP( FRP_LOW + "Player joined, updating him on state" + FRP_END );
-
-      // Send all the other states they need to catch up on
-      _b7_send( (byte)( k_7b_menu_loc | menu_loc ) );
-      _b7_send( (byte)( k_7b_ball_col | colour_id ) );
-      _b7_send( (byte)( k_7b_timelimit | timer_id ) );
-      _b7_send( (byte)( k_7b_gamemode | gamemode_id ) );
-   }
-}
+            // Send all the other states they need to catch up on
+            Send((byte)(sevenBallMenuLocation | menuLocation));
+            Send((byte)(sevenBallCol | colourID));
+            Send((byte)(sevenBallTeams | teamsAllowed));
+            Send((byte)(sevenBallTimeLimit | timerID));
+            Send((byte)(sevenBallGameMode | gameModeID));
+        }
+    }
 
 #endif
 
-public void Start()
-{
-   // getting inspector variables from ht8b.cs
-   ball_textures = main.textureSets;
-   ball_renderers = main.balls_render;
-   ball_material = main.ballMaterial;
-   table_material = main.tableMaterial;
-   scorecard = main.scoreCardRenderer.gameObject;
+#if USE_KING_LOBBY // TODO: Figure out what this ifdef is for.
+    void OnPlayerJoined(VRCPlayerApi player) // TODO: Handle this duplicated subscription to OnPlayerJoined
+    {
+        // Ignore this if we are the one joining
+        if(player == Networking.LocalPlayer) {
+            return;
+        }
 
-   for( int i = 0; i < 16; i ++ )
-   {
-      reset_positions[ i ] = ball_renderers[ i ].transform.position;
-   }
+        if(Networking.GetOwner(main.gameObject) == Networking.LocalPlayer)
+        {
+            // Send all the other states they need to catch up on
+            Send((byte)(k_7b_menu_loc | menu_loc));
+            Send((byte)(k_7b_ball_col | colour_id));
+            Send((byte)(k_7b_timelimit | timer_id));
+            Send((byte)(k_7b_gamemode | gamemode_id));
+        }
+    }
+#endif
 
-   // Initialize visual state to match internal
-   _internal_state_reset();
-}
 
-void _transition_apex()
-{
-   ball_material.SetTexture( "_MainTex", ball_textures[ colour_id ] );
+    private void ApexTransition()
+    {
+        ballMat.SetTexture("_MainTex", ballTextures[colourID]);
 
-   for( int i = 0; i < 16; i ++ )
-   {
-      ball_renderers[ i ].transform.position = reset_positions[ i ];
+        for (int i = 0; i < 16; i++)
+        {
+            ballRenderers[i].transform.position = resetPositions[i];
 
-      if( gamemode_id == 1u )
-      {
-         if( i >= 10 )
-         {
-            ball_renderers[ i ].SetActive( false );
-         }
-         else
-         {
-            ball_renderers[ i ].SetActive( true );
-         }
-      }
-      else
-      {
-         ball_renderers[ i ].SetActive( true );
-      }
-   }
+            if (gameModeID == 1u)
+            {
+                if (i >= 10)
+                {
+                    ballRenderers[i].SetActive(false);
+                }
+                else
+                {
+                    ballRenderers[i].SetActive(true);
+                }
+            }
+            else
+            {
+                ballRenderers[i].SetActive(true);
+            }
+        }
 
-}
+    }
 
 #if USE_AUTH_LOBBY
-void _lobby_refresh()
-{
-   _players_view();
-}
+    void RefreshLobby()
+    {
+        ViewPlayers();
+    }
 #endif
 
-float last_check = 0.0f;
-public void Update()
-{
-   #if USE_AUTH_LOBBY
-   if( Time.timeSinceLevelLoad > last_check + 1.5f )
-   {
-      last_check = Time.timeSinceLevelLoad;
-      _lobby_refresh();
-   }
-   #endif
 
-   if( colourchange_timer <= k_COLOUR_TRANSITION )
-   {
-      colourchange_timer -= Time.deltaTime;
+    // MENU BUTTON INPUTS
+    // ===================================================================================================================================================================================
 
-      if( colourchange_timer < 0.0f )
-      {
-         if( !has_transitioned )
-         {
-            _transition_apex();
-            has_transitioned = true;
-         }
-      }
-
-      float scaling = Mathf.Abs( colourchange_timer ) * k_COLOUR_TRANS_RECIP;
-
-      if( colourchange_timer < -k_COLOUR_TRANSITION )
-      {
-         colourchange_timer = 9.0f;
-
-         scaling = 1.0f;
-      }
-
-      for( int i = 0; i < 16; i ++ )
-      {
-         ball_renderers[ i ].transform.localScale = new Vector3( scaling, scaling, scaling );
-      }
-   }
-
-   if( menu_loc == 0 )
-   {
-      table_light_colour = table_src_light * (Mathf.Sin( Time.timeSinceLevelLoad * 3.0f) * 0.5f + 1.0f);
-   }
-   else
-   {
-      table_light_colour = Color.Lerp( table_light_colour, table_src_light, Time.deltaTime * 5.0f );
-      table_current_colour = Color.Lerp( table_current_colour, table_src_colour, Time.deltaTime * 5.0f );
-      table_material.SetColor( "_ClothColour", table_current_colour );
-   }
-
-   table_material.SetColor( "_EmissionColour", new Color( table_light_colour.r, table_light_colour.g, table_light_colour.b, 0.0f ) );
-
-   sand_timer_weight = Mathf.Lerp( sand_timer_weight, sand_timer_target_weight, Time.deltaTime * 5.0f );
-   mr_sand_timer.SetBlendShapeWeight( 0, sand_timer_weight );
-}
-
-
-void _frp( string ln )
-{
-   Debug.Log( "[<color=\"#B5438F\">ht8b</color>] " + ln );
-}
-
-// MENU BUTTON INPUTS
-// ===================================================================================================================================================================================
-[HideInInspector] public int _in_joinas_id = 0;
-public void _on_joinas()
-{
+    public void _on_joinas()
+    {
 #if USE_AUTH_LOBBY
-   int player_count = 0;
-   for( int i = 0; i < 4; i ++ )
-   {
-      if( player_ready[ i ] )
-         player_count ++;
-   }
+        int playerCount = 0;
+        for (int i = 0; i < 4; i++)
+        {
+            if (playersReadyStatus[i])
+            {
+                playerCount++;
+            }
+        }
 
-   if( player_ready[ _in_joinas_id ] )
-   {
-      if( local_playerid == _in_joinas_id )
-      {
-         // Normal lobby leave
-         _frp( FRP_WARN + "Leaving lobby as " + local_playerid + FRP_END );
-         local_playerid = -1;
+        if (playersReadyStatus[joinAsID])
+        {
+            if (localPlayerID == joinAsID)
+            {
+                // Normal lobby leave
+                localPlayerID = -1;
 
-         // Networked leave
-         _b7_send( (byte)(k_7b_leave | _in_joinas_id) );
-      }
-      else
-      {
-         //  Error Tried to join someone elses slot
-#if UNITY_EDITOR
-         _frp( FRP_ERR + "Tried to join as player " + _in_joinas_id + ", but player <UNITY_EDITOR> was already registered there" );
-#else
-         _frp( FRP_ERR + "Tried to join as player " + _in_joinas_id + ", but player " + Networking.GetOwner( gm_tokens[ _in_joinas_id ] ).displayName + " was already registered there" );
+                // Networked leave
+                Send((byte)(sevenBallLeave | joinAsID));
+            }
+            else
+            {
+                Debug.LogError($"ht8b_menu: JoinAs: tried to join as player {joinAsID} but player {Networking.GetOwner(tokens[joinAsID]).displayName} was already registered there");
+            }
+        }
+        else
+        {
+            if (localPlayerID != -1)
+            {
+                Debug.LogError($"ht8b_menu: JoinAs: Tried to join as player {joinAsID}, but already in the game as {localPlayerID}. UI is lagged.");
+            }
+            else
+            {
+                if (playerCount == 0 && joinAsID != 0)
+                {
+                    // Force first joiner to host
+                    Debug.LogWarning("ht8b_menu: JoinAs: Switching to host automatically.");
+                    joinAsID = 0;
+                }
+
+                // Normal lobby join
+                localPlayerID = joinAsID;
+
+                // This is simply a hack for name transmission cause yeee
+                Networking.SetOwner(Networking.LocalPlayer, tokens[localPlayerID]);
+
+                // Networked join
+                Send((byte)(sevenBallJoin | joinAsID));
+            }
+        }
 #endif
-      }
-   }
-   else
-   {
-      if( local_playerid != -1 )
-      {
-         // Error join
-         _frp( FRP_ERR + "Tried to join as player " + _in_joinas_id + ", but already in the game as " + local_playerid + ". UI is lagged." + FRP_END );
-      }
-      else
-      {
-         if( player_count == 0 && _in_joinas_id != 0 )
-         {
-            // Force first joiner to host
-            _frp( FRP_WARN + "Switching to host automatically" + FRP_END );
-            _in_joinas_id = 0;
-         }
+    }
 
-         // Normal lobby join
-         _frp( FRP_YES + "Joining as " + _in_joinas_id + FRP_END );
-         local_playerid = _in_joinas_id;
 
-         // This is simply a hack for name transmission cause yeee
-         Networking.SetOwner( Networking.LocalPlayer, gm_tokens[ local_playerid ] );
-
-         // Networked join
-         _b7_send( (byte)(k_7b_join | _in_joinas_id) );
-      }
-   }
-#endif
-}
-
-// Change menu location button
-[HideInInspector] public uint _in_menu_loc = 0;
-public void _on_menu_change()
-{
+    public void OnMenuChange()
+    {
 #if USE_AUTH_LOBBY
-   // Only allow one way 0->1 change at the moment.
-   if( local_playerid == 0 )
-   {
+        // Only allow one way 0->1 change at the moment.
+        if (localPlayerID == 0)
+        {
 #endif
-      if( _in_menu_loc == 1 )
-      {
-         menu_loc = _in_menu_loc;
+            if (inMenuLocation == 1)
+            {
+                menuLocation = inMenuLocation;
 
-         // Networked menu change
-         _b7_send( (byte)(k_7b_menu_loc | menu_loc) );
-      }
-      else
-      {
-         _frp( FRP_ERR + "Menu transitions other than 0->1 are not implemented" + FRP_END );
-      }
+                // Networked menu change
+                Send((byte)(sevenBallMenuLocation | menuLocation));
+            }
+            else
+            {
+                Debug.LogError("ht8b_menu: OnMenuChange: Menu transitions other than 0->1 are not implemented");
+            }
 #if USE_AUTH_LOBBY
-   }
-   else
-   {
-      _frp( FRP_ERR + "Cannot change menu state as we are not the lobby leader" + FRP_END );
-   }
+        }
+        else
+        {
+            Debug.LogError("ht8b_menu: OnMenuChange: Cannot change menu state as we are not the lobby leader");
+        }
 #endif
-}
+    }
 
-// Change colourset
-[HideInInspector] public int _in_colourchange_dir = 0;
-public void _on_colourchange()
-{
+    // Change colourset
+
+    public void OnColourChange()
+    {
 #if USE_AUTH_LOBBY
-   if( local_playerid == 0 )
-   {
+        if (localPlayerID == 0)
+        {
 #endif
-      int newcol = (int)colour_id + _in_colourchange_dir;
+            int newcol = (int)colourID + colourChangeDir;
 
-      if( newcol < 0 )
-      {
-         newcol = (int)_colour_max;
-      }
+            if (newcol < 0)
+            {
+                newcol = (int)maxColour;
+            }
 
-      if( newcol > _colour_max )
-      {
-         newcol = 0;
-      }
+            if (newcol > maxColour)
+            {
+                newcol = 0;
+            }
 
-      colour_id = (uint)newcol;
+            colourID = (uint)newcol;
 
-      // Networked colour change
-      _b7_send( (byte)( k_7b_ball_col | colour_id ) );
+            // Networked colour change
+            Send((byte)(sevenBallCol | colourID));
 
-      // Local view
-      _colours_view();
+            // Local view
+            ViewColours();
 #if USE_AUTH_LOBBY
-   }
-   else
-   {
-      _frp( FRP_ERR + "Cannot change ball colours when not the lobby leader" + FRP_END );
-   }
+        }
+        else
+        {
+            Debug.LogError("ht8b_menu: OnColourChange: Cannot change ball colours when not the lobby leader");
+        }
 #endif
-}
+    }
 
-[HideInInspector] public int _in_allow_teams = 0;
-public void _on_teamallowchange()
-{
+
+    public void OnTeamAllowChange()
+    {
 #if USE_AUTH_LOBBY
-   if( local_playerid == 0 )
-   {
+        if (localPlayerID == 0)
+        {
 #endif
+            teamsAllowed = (uint)allowTeams;
 
-      teams_allowed = (uint)_in_allow_teams;
-
-      // Networked team allow
-      _b7_send( (byte)( k_7b_teams | teams_allowed ) );
+            // Networked team allow
+            Send((byte)(sevenBallTeams | teamsAllowed));
 
 #if USE_AUTH_LOBBY
-   }
-   else
-   {
-      _frp( FRP_ERR + "Cannot change team settings if not the lobby leader" + FRP_END );
-   }
+        }
+        else
+        {
+            Debug.LogError("ht8b_menu: OnMenuChange: Cannot change team settings if not the lobby leader");
+        }
 #endif
-}
+    }
 
-[HideInInspector] public int _in_timelimitid = 0;
-public void _on_timelimitchange()
-{
+
+    public void _on_timelimitchange()
+    {
 #if USE_AUTH_LOBBY
-   if( local_playerid == 0 )
-   {
+        if (localPlayerID == 0)
+        {
 #endif
 
-      timer_id = (uint)_in_timelimitid;
+            timerID = (uint)timeLimitID;
 
-      // Networked timelimit update
-      _b7_send( (byte)( k_7b_timelimit | timer_id ) );
-
-#if USE_AUTH_LOBBY
-   }
-   else
-   {
-      _frp( FRP_ERR + "Cannot change time limit if not lobby leader" + FRP_END );
-   }
-#endif
-}
-
-[HideInInspector] public int _in_gamemodeid = 0;
-public void _on_gamemode_change()
-{
-#if USE_AUTH_LOBBY
-   if( local_playerid == 0 )
-   {
-#endif
-      // If 9 ball, disable colour
-      if( _in_gamemodeid == 1 )
-      {
-         colour_id = 3U;
-         _colours_view();
-         _b7_send( (byte)( k_7b_ball_col | colour_id ) );
-      }
-      else
-      {
-         // US is locked to gamemode 1 so we have to reset colour ID
-         if( gamemode_id == 1u )
-         {
-            colour_id = 0U;
-            _colours_view();
-            _b7_send( (byte)( k_7b_ball_col | colour_id ) );
-         }
-      }
-
-      gamemode_id = (uint)_in_gamemodeid;
-
-      // Networked gamemode change
-      _b7_send( (byte)( k_7b_gamemode | gamemode_id ) );
+            // Networked timelimit update
+            Send((byte)(sevenBallTimeLimit | timerID));
 
 #if USE_AUTH_LOBBY
-   }
-   else
-   {
-      _frp( FRP_ERR + "Cannot change gamemode if not lobby leader" + FRP_END );
-   }
+        }
+        else
+        {
+            Debug.LogError("ht8b_menu: OnTeamAllowChange: Cannot change time limit if not lobby leader");
+        }
 #endif
-}
+    }
 
-// ==============================================================================================================================================================================
+
+    public void OnGameModeChange()
+    {
+#if USE_AUTH_LOBBY
+        if (localPlayerID == 0)
+        {
+#endif
+            // If 9 ball, disable colour
+            if (inputGameModeID == 1)
+            {
+                colourID = 3U;
+                ViewColours();
+                Send((byte)(sevenBallCol | colourID));
+            }
+            else
+            {
+                // US is locked to gamemode 1 so we have to reset colour ID
+                if (gameModeID == 1u)
+                {
+                    colourID = 0U;
+                    ViewColours();
+                    Send((byte)(sevenBallCol | colourID));
+                }
+            }
+
+            gameModeID = (uint)inputGameModeID;
+
+            // Networked gamemode change
+            Send((byte)(sevenBallGameMode | gameModeID));
+
+#if USE_AUTH_LOBBY
+        }
+        else
+        {
+            Debug.LogError("ht8b_menu: OnGameModeChange: Cannot change gamemode if not lobby leader");
+        }
+#endif
+    }
+
+    // ==============================================================================================================================================================================
 
 #if USE_AUTH_LOBBY
 
-void _api_users_refresh()
-{
-   for( int i = 0; i < 4; i ++ )
-   {
-      player_apis[ i ] = Networking.GetOwner( gm_tokens[ i ] );
-   }
-}
+    void RefreshUsersAPI()
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            playerAPIs[i] = Networking.GetOwner(tokens[i]);
+        }
+    }
 
 #endif
 
-// Send 7 bits over the network
-void _b7_send( byte data )
-{
-   if( game_is_running )
-   {
-      _frp( FRP_ERR + "Tried to _b7_send while game was running" + FRP_END );
-      return;
-   }
+    // Send 7 bits over the network
+    void Send(byte data)
+    {
+        if (isGameRunning)
+        {
+            Debug.LogError("ht8b_menu: Send: Tried to Send while game was running");
+            return;
+        }
 
-   if( (data & 0x80U) > 0 )
-   {
-      _frp( FRP_ERR + "Tried to send more than 7 bits..." + FRP_END );
-
-      return;
-   }
+        if ((data & 0x80U) > 0)
+        {
+            Debug.LogError("ht8b_menu: Send: Tried to send more than 7 bits");
+            return;
+        }
 
 #if UNITY_EDITOR
-   this.SendCustomEvent( "B7" + data.ToString("X2") );
+        SendCustomEvent("B7" + data.ToString("X2"));
 #else
-   this.SendCustomNetworkEvent( VRC.Udon.Common.Interfaces.NetworkEventTarget.All, "B7" + data.ToString("X2") );
+        SendCustomNetworkEvent( VRC.Udon.Common.Interfaces.NetworkEventTarget.All, "B7" + data.ToString("X2"));
 #endif
-}
+    }
 
-// Recieve 7 bits from network
-private void _b7_proc( byte data )
-{
-   if( !this.gameObject.activeSelf )
-   {
-      _frp( FRP_ERR + "Tried to run _b7_proc while this gameobject was disabled" + FRP_END );
-      return;
-   }
+    // Recieve 7 bits from network
+    private void Receive(byte data)
+    {
+        if (!gameObject.activeSelf)
+        {
+            Debug.LogError("ht8b_menu: Receive: Tried to run while this gameobject was disabled");
+            return;
+        }
 
-   uint msgid = data & 0x70U;
+        uint msgID = data & 0x70U;
 
-   if (msgid == k_7b_join)                                                 // EV 0x00: Player join
-   {
+        if (msgID == sevenBallJoin)                                                 // EV 0x00: Player join
+        {
 #if USE_AUTH_LOBBY
-      uint playerid = (data & 0x3U);
+            uint playerid = (data & 0x3U);
+            playersReadyStatus[playerid] = true;
 
-      _frp( FRP_YES + ".recv: Join player: " + playerid + FRP_END );
-      player_ready[ playerid ] = true;
-
-      _players_view();
+            ViewPlayers();
 #else
-
-      _frp(FRP_ERR + ".recv: Join player. ht8b was compiled without auth lobby enabled" + FRP_END);
-
+            Debug.LogError("ht8b_menu: Receive: ht8b was compiled without auth lobby enabled");  
 #endif
-   } 
-   else if (msgid == k_7b_leave)                                            // EV 0x01: Player leave
-   {
+        }
+        else if (msgID == sevenBallLeave)                                            // EV 0x01: Player leave
+        {
 #if USE_AUTH_LOBBY
-      uint playerid = (data & 0x3U);
+            uint playerid = (data & 0x3U);
 
-      _frp( FRP_WARN + ".recv: Leave player: " + playerid + FRP_END );
-      
-      if( playerid == 0x00 )
-      {
-         _frp( FRP_WARN + "Lobby leader left, resetting" + FRP_END );
-         _internal_state_reset();
-      }
-      else
-      {
-         player_ready[ playerid ] = false;
-      }
-      _players_view();
+            if (playerid == 0x00)
+            {
+                ResetInternalState();
+            }
+            else
+            {
+                playersReadyStatus[playerid] = false;
+            }
+            ViewPlayers();
 #else
-      _frp(FRP_ERR + ".recv: Leave player. ht8b was compiled without auth lobby enabled" + FRP_END);
+      Debug.LogError("ht8b_menu: Receive: ht8b was compiled without auth lobby enabled");  
 #endif
-   } 
-   else if (msgid == k_7b_nj_players)                                          // EV 0x02: New join, playing status update
-   {
+        }
+        else if (msgID == sevenBallNewJoinPlayer)                                          // EV 0x02: New join, playing status update
+        {
 #if USE_AUTH_LOBBY
-      _frp( FRP_LOW + ".recv: Lobby playing status" + FRP_END );
-      for( int i = 0; i < 4; i ++ )
-      {
-         player_ready[ i ] = ((data >> i) & 0x1) > 0;
-      }
+            for (int i = 0; i < 4; i++)
+            {
+                playersReadyStatus[i] = ((data >> i) & 0x1) > 0;
+            }
 
-      _players_view();
+            ViewPlayers();
 #else
-      _frp( FRP_ERR + ".recv: New join status. ht8b was compiled without auth lobby enabled" + FRP_END );
+      Debug.LogError("ht8b_menu: Receive: ht8b was compiled without auth lobby enabled");  
 #endif
-   }
-   else if( msgid == k_7b_menu_loc )                                          // EV 0x03: Menu location change
-   {
-      _frp( FRP_LOW + ".recv: Menu change location" + FRP_END );
+        }
+        else if (msgID == sevenBallMenuLocation)                                          // EV 0x03: Menu location change
+        {
+            menuLocation = data & 0xfu;
+            ViewMenu();
+        }
+        else if (msgID == sevenBallCol)                                          // EV 0x04: Ball colours
+        {
+            uint newid = (data & 0x3U);
+            if (newid != colourID)
+            {
+                colourID = newid;
+                ViewColours();
+            }
+        }
+        else if (msgID == sevenBallGameMode)                                          // Ev 0x05: Gamemode
+        {
+            gameModeID = data & 0x3u;
 
-      menu_loc = data & 0xfu;
-      _menu_view();
-   }
-   else if( msgid == k_7b_ball_col )                                          // EV 0x04: Ball colours
-   {
-      _frp( FRP_LOW + ".recv: Colour change" + FRP_END );
+            ViewGameMode();
+#if USE_AUTH_LOBBY
+            ViewPlayers();
+#endif
+        }
+        else if (msgID == sevenBallTimeLimit)                                         // EV 0x06: Timelimit
+        {
+            timerID = data & 0x3U;
 
-      uint newid = (data & 0x3U);
-      if( newid != colour_id )
-      {
-         colour_id = newid;
-         _colours_view();
-      }
-   }
-   else if( msgid == k_7b_gamemode )                                          // Ev 0x05: Gamemode
-   {
-      _frp( FRP_LOW + ".recv: Gamemode change" + FRP_END );
+            if (timerID == 3U)
+            {
+                Debug.LogError("ht8b_menu: Receive: got timer ID 3, this is undefined. Something went wrong in network transmission");
+                timerID = 2U;
+            }
 
-      gamemode_id = data & 0x3u;
+            ViewTimeLimit();
+        }
+        else if (msgID == sevenBallTeams)                                             // EV 0x07: Teams
+        {
+#if USE_AUTH_LOBBY
+            teamsAllowed = data & 0x1U;
 
-      _gamemode_view();
-      #if USE_AUTH_LOBBY
-      _players_view();
-      #endif
-   }
-   else if( msgid == k_7b_timelimit )                                         // EV 0x06: Timelimit
-   {
-      _frp( FRP_LOW + ".recv: Timelimit change" + FRP_END );
+            if (teamsAllowed == 0 && localPlayerID > 1)
+            {
+                Debug.LogWarning("ht8b_menu: Receive: Auth lobby enabled and too many local players.");
+                Send((byte)(sevenBallLeave | (uint)localPlayerID));
 
-      timer_id = data & 0x3U;
+                localPlayerID = -1;
+            }
 
-      if( timer_id == 3U )
-      {
-         _frp( FRP_ERR + "got timer ID 3, this is undefined. Something went wrong in network transmission" + FRP_END );
-         timer_id = 2U;
-      }
+            ViewTeam();
+            ViewPlayers();
+#else
 
-      _timelimit_view();
-   }
-   else if( msgid == k_7b_teams )                                             // EV 0x07: Teams
-   {
-      #if USE_AUTH_LOBBY
-      _frp( FRP_LOW + ".recv: Team allow change" + FRP_END );
+      Debug.LogError("ht8b_menu: Receive: ht8b was compiled without auth lobby enabled");  
 
-      teams_allowed = data & 0x1U;
+#endif
+        }
+        else
+        {
+            Debug.LogError($"ht8b_menu: Receive: Unknown message ID {msgID}");
+        }
+    }
 
-      // Get out of the lobby!!! QUIIIIIIIIIIICK
-      if( teams_allowed == 0 && local_playerid > 1 )
-      {
-         _frp( FRP_WARN + "We can't fit in this lobby anymore sadge" + FRP_END );
-         _b7_send( (byte)( k_7b_leave | (uint)local_playerid ) );
-
-         local_playerid = -1;
-      }
-
-      _team_view();
-      _players_view();
-      #else
-
-      _frp( FRP_ERR + ".recv: New join status. ht8b was compiled without auth lobby enabled" + FRP_END );
-
-      #endif
-   }
-   else
-   {
-      // This state will never be hit unless the solar system gets sucked into a black hole
-      _frp( FRP_ERR + ".recv: Unkown message ID (" + msgid + ")" + FRP_END );
-   }
-}
-
-// VRChat
-public void B700(){ _b7_proc( 0x0 ); }
-public void B701(){ _b7_proc( 0x1 ); }
-public void B702(){ _b7_proc( 0x2 ); }
-public void B703(){ _b7_proc( 0x3 ); }
-public void B704(){ _b7_proc( 0x4 ); }
-public void B705(){ _b7_proc( 0x5 ); }
-public void B706(){ _b7_proc( 0x6 ); }
-public void B707(){ _b7_proc( 0x7 ); }
-public void B708(){ _b7_proc( 0x8 ); }
-public void B709(){ _b7_proc( 0x9 ); }
-public void B70A(){ _b7_proc( 0xa ); }
-public void B70B(){ _b7_proc( 0xb ); }
-public void B70C(){ _b7_proc( 0xc ); }
-public void B70D(){ _b7_proc( 0xd ); }
-public void B70E(){ _b7_proc( 0xe ); }
-public void B70F(){ _b7_proc( 0xf ); }
-public void B710(){ _b7_proc( 0x10 ); }
-public void B711(){ _b7_proc( 0x11 ); }
-public void B712(){ _b7_proc( 0x12 ); }
-public void B713(){ _b7_proc( 0x13 ); }
-public void B714(){ _b7_proc( 0x14 ); }
-public void B715(){ _b7_proc( 0x15 ); }
-public void B716(){ _b7_proc( 0x16 ); }
-public void B717(){ _b7_proc( 0x17 ); }
-public void B718(){ _b7_proc( 0x18 ); }
-public void B719(){ _b7_proc( 0x19 ); }
-public void B71A(){ _b7_proc( 0x1a ); }
-public void B71B(){ _b7_proc( 0x1b ); }
-public void B71C(){ _b7_proc( 0x1c ); }
-public void B71D(){ _b7_proc( 0x1d ); }
-public void B71E(){ _b7_proc( 0x1e ); }
-public void B71F(){ _b7_proc( 0x1f ); }
-public void B720(){ _b7_proc( 0x20 ); }
-public void B721(){ _b7_proc( 0x21 ); }
-public void B722(){ _b7_proc( 0x22 ); }
-public void B723(){ _b7_proc( 0x23 ); }
-public void B724(){ _b7_proc( 0x24 ); }
-public void B725(){ _b7_proc( 0x25 ); }
-public void B726(){ _b7_proc( 0x26 ); }
-public void B727(){ _b7_proc( 0x27 ); }
-public void B728(){ _b7_proc( 0x28 ); }
-public void B729(){ _b7_proc( 0x29 ); }
-public void B72A(){ _b7_proc( 0x2a ); }
-public void B72B(){ _b7_proc( 0x2b ); }
-public void B72C(){ _b7_proc( 0x2c ); }
-public void B72D(){ _b7_proc( 0x2d ); }
-public void B72E(){ _b7_proc( 0x2e ); }
-public void B72F(){ _b7_proc( 0x2f ); }
-public void B730(){ _b7_proc( 0x30 ); }
-public void B731(){ _b7_proc( 0x31 ); }
-public void B732(){ _b7_proc( 0x32 ); }
-public void B733(){ _b7_proc( 0x33 ); }
-public void B734(){ _b7_proc( 0x34 ); }
-public void B735(){ _b7_proc( 0x35 ); }
-public void B736(){ _b7_proc( 0x36 ); }
-public void B737(){ _b7_proc( 0x37 ); }
-public void B738(){ _b7_proc( 0x38 ); }
-public void B739(){ _b7_proc( 0x39 ); }
-public void B73A(){ _b7_proc( 0x3a ); }
-public void B73B(){ _b7_proc( 0x3b ); }
-public void B73C(){ _b7_proc( 0x3c ); }
-public void B73D(){ _b7_proc( 0x3d ); }
-public void B73E(){ _b7_proc( 0x3e ); }
-public void B73F(){ _b7_proc( 0x3f ); }
-public void B740(){ _b7_proc( 0x40 ); }
-public void B741(){ _b7_proc( 0x41 ); }
-public void B742(){ _b7_proc( 0x42 ); }
-public void B743(){ _b7_proc( 0x43 ); }
-public void B744(){ _b7_proc( 0x44 ); }
-public void B745(){ _b7_proc( 0x45 ); }
-public void B746(){ _b7_proc( 0x46 ); }
-public void B747(){ _b7_proc( 0x47 ); }
-public void B748(){ _b7_proc( 0x48 ); }
-public void B749(){ _b7_proc( 0x49 ); }
-public void B74A(){ _b7_proc( 0x4a ); }
-public void B74B(){ _b7_proc( 0x4b ); }
-public void B74C(){ _b7_proc( 0x4c ); }
-public void B74D(){ _b7_proc( 0x4d ); }
-public void B74E(){ _b7_proc( 0x4e ); }
-public void B74F(){ _b7_proc( 0x4f ); }
-public void B750(){ _b7_proc( 0x50 ); }
-public void B751(){ _b7_proc( 0x51 ); }
-public void B752(){ _b7_proc( 0x52 ); }
-public void B753(){ _b7_proc( 0x53 ); }
-public void B754(){ _b7_proc( 0x54 ); }
-public void B755(){ _b7_proc( 0x55 ); }
-public void B756(){ _b7_proc( 0x56 ); }
-public void B757(){ _b7_proc( 0x57 ); }
-public void B758(){ _b7_proc( 0x58 ); }
-public void B759(){ _b7_proc( 0x59 ); }
-public void B75A(){ _b7_proc( 0x5a ); }
-public void B75B(){ _b7_proc( 0x5b ); }
-public void B75C(){ _b7_proc( 0x5c ); }
-public void B75D(){ _b7_proc( 0x5d ); }
-public void B75E(){ _b7_proc( 0x5e ); }
-public void B75F(){ _b7_proc( 0x5f ); }
-public void B760(){ _b7_proc( 0x60 ); }
-public void B761(){ _b7_proc( 0x61 ); }
-public void B762(){ _b7_proc( 0x62 ); }
-public void B763(){ _b7_proc( 0x63 ); }
-public void B764(){ _b7_proc( 0x64 ); }
-public void B765(){ _b7_proc( 0x65 ); }
-public void B766(){ _b7_proc( 0x66 ); }
-public void B767(){ _b7_proc( 0x67 ); }
-public void B768(){ _b7_proc( 0x68 ); }
-public void B769(){ _b7_proc( 0x69 ); }
-public void B76A(){ _b7_proc( 0x6a ); }
-public void B76B(){ _b7_proc( 0x6b ); }
-public void B76C(){ _b7_proc( 0x6c ); }
-public void B76D(){ _b7_proc( 0x6d ); }
-public void B76E(){ _b7_proc( 0x6e ); }
-public void B76F(){ _b7_proc( 0x6f ); }
-public void B770(){ _b7_proc( 0x70 ); }
-public void B771(){ _b7_proc( 0x71 ); }
-public void B772(){ _b7_proc( 0x72 );}
-public void B773(){ _b7_proc( 0x73 ); }
-public void B774(){ _b7_proc( 0x74 ); }
-public void B775(){ _b7_proc( 0x75 ); }
-public void B776(){ _b7_proc( 0x76 ); }
-public void B777(){ _b7_proc( 0x77 ); }
-public void B778(){ _b7_proc( 0x78 ); }
-public void B779(){ _b7_proc( 0x79 ); }
-public void B77A(){ _b7_proc( 0x7a ); }
-public void B77B(){ _b7_proc( 0x7b ); }
-public void B77C(){ _b7_proc( 0x7c ); }
-public void B77D(){ _b7_proc( 0x7d ); }
-public void B77E(){ _b7_proc( 0x7e ); }
-public void B77F(){ _b7_proc( 0x7f ); }
-
+    // VRChat
+    public void B700() { Receive(0x0); }
+    public void B701() { Receive(0x1); }
+    public void B702() { Receive(0x2); }
+    public void B703() { Receive(0x3); }
+    public void B704() { Receive(0x4); }
+    public void B705() { Receive(0x5); }
+    public void B706() { Receive(0x6); }
+    public void B707() { Receive(0x7); }
+    public void B708() { Receive(0x8); }
+    public void B709() { Receive(0x9); }
+    public void B70A() { Receive(0xa); }
+    public void B70B() { Receive(0xb); }
+    public void B70C() { Receive(0xc); }
+    public void B70D() { Receive(0xd); }
+    public void B70E() { Receive(0xe); }
+    public void B70F() { Receive(0xf); }
+    public void B710() { Receive(0x10); }
+    public void B711() { Receive(0x11); }
+    public void B712() { Receive(0x12); }
+    public void B713() { Receive(0x13); }
+    public void B714() { Receive(0x14); }
+    public void B715() { Receive(0x15); }
+    public void B716() { Receive(0x16); }
+    public void B717() { Receive(0x17); }
+    public void B718() { Receive(0x18); }
+    public void B719() { Receive(0x19); }
+    public void B71A() { Receive(0x1a); }
+    public void B71B() { Receive(0x1b); }
+    public void B71C() { Receive(0x1c); }
+    public void B71D() { Receive(0x1d); }
+    public void B71E() { Receive(0x1e); }
+    public void B71F() { Receive(0x1f); }
+    public void B720() { Receive(0x20); }
+    public void B721() { Receive(0x21); }
+    public void B722() { Receive(0x22); }
+    public void B723() { Receive(0x23); }
+    public void B724() { Receive(0x24); }
+    public void B725() { Receive(0x25); }
+    public void B726() { Receive(0x26); }
+    public void B727() { Receive(0x27); }
+    public void B728() { Receive(0x28); }
+    public void B729() { Receive(0x29); }
+    public void B72A() { Receive(0x2a); }
+    public void B72B() { Receive(0x2b); }
+    public void B72C() { Receive(0x2c); }
+    public void B72D() { Receive(0x2d); }
+    public void B72E() { Receive(0x2e); }
+    public void B72F() { Receive(0x2f); }
+    public void B730() { Receive(0x30); }
+    public void B731() { Receive(0x31); }
+    public void B732() { Receive(0x32); }
+    public void B733() { Receive(0x33); }
+    public void B734() { Receive(0x34); }
+    public void B735() { Receive(0x35); }
+    public void B736() { Receive(0x36); }
+    public void B737() { Receive(0x37); }
+    public void B738() { Receive(0x38); }
+    public void B739() { Receive(0x39); }
+    public void B73A() { Receive(0x3a); }
+    public void B73B() { Receive(0x3b); }
+    public void B73C() { Receive(0x3c); }
+    public void B73D() { Receive(0x3d); }
+    public void B73E() { Receive(0x3e); }
+    public void B73F() { Receive(0x3f); }
+    public void B740() { Receive(0x40); }
+    public void B741() { Receive(0x41); }
+    public void B742() { Receive(0x42); }
+    public void B743() { Receive(0x43); }
+    public void B744() { Receive(0x44); }
+    public void B745() { Receive(0x45); }
+    public void B746() { Receive(0x46); }
+    public void B747() { Receive(0x47); }
+    public void B748() { Receive(0x48); }
+    public void B749() { Receive(0x49); }
+    public void B74A() { Receive(0x4a); }
+    public void B74B() { Receive(0x4b); }
+    public void B74C() { Receive(0x4c); }
+    public void B74D() { Receive(0x4d); }
+    public void B74E() { Receive(0x4e); }
+    public void B74F() { Receive(0x4f); }
+    public void B750() { Receive(0x50); }
+    public void B751() { Receive(0x51); }
+    public void B752() { Receive(0x52); }
+    public void B753() { Receive(0x53); }
+    public void B754() { Receive(0x54); }
+    public void B755() { Receive(0x55); }
+    public void B756() { Receive(0x56); }
+    public void B757() { Receive(0x57); }
+    public void B758() { Receive(0x58); }
+    public void B759() { Receive(0x59); }
+    public void B75A() { Receive(0x5a); }
+    public void B75B() { Receive(0x5b); }
+    public void B75C() { Receive(0x5c); }
+    public void B75D() { Receive(0x5d); }
+    public void B75E() { Receive(0x5e); }
+    public void B75F() { Receive(0x5f); }
+    public void B760() { Receive(0x60); }
+    public void B761() { Receive(0x61); }
+    public void B762() { Receive(0x62); }
+    public void B763() { Receive(0x63); }
+    public void B764() { Receive(0x64); }
+    public void B765() { Receive(0x65); }
+    public void B766() { Receive(0x66); }
+    public void B767() { Receive(0x67); }
+    public void B768() { Receive(0x68); }
+    public void B769() { Receive(0x69); }
+    public void B76A() { Receive(0x6a); }
+    public void B76B() { Receive(0x6b); }
+    public void B76C() { Receive(0x6c); }
+    public void B76D() { Receive(0x6d); }
+    public void B76E() { Receive(0x6e); }
+    public void B76F() { Receive(0x6f); }
+    public void B770() { Receive(0x70); }
+    public void B771() { Receive(0x71); }
+    public void B772() { Receive(0x72); }
+    public void B773() { Receive(0x73); }
+    public void B774() { Receive(0x74); }
+    public void B775() { Receive(0x75); }
+    public void B776() { Receive(0x76); }
+    public void B777() { Receive(0x77); }
+    public void B778() { Receive(0x78); }
+    public void B779() { Receive(0x79); }
+    public void B77A() { Receive(0x7a); }
+    public void B77B() { Receive(0x7b); }
+    public void B77C() { Receive(0x7c); }
+    public void B77D() { Receive(0x7d); }
+    public void B77E() { Receive(0x7e); }
+    public void B77F() { Receive(0x7f); }
 }

--- a/us/ht8b_menusetter.cs
+++ b/us/ht8b_menusetter.cs
@@ -8,76 +8,76 @@ using VRC.Udon;
 public class ht8b_menusetter : UdonSharpBehaviour
 {
 
-[SerializeField] int colourSet = 0;
-[SerializeField] int gameMode = -1;
-[SerializeField] int timer = -1;
-[SerializeField] int joinPlayer = -1;
-[SerializeField] int menu_loc = -1;
-[SerializeField] int allowTeams = -1;
+    public int colourSet = 0;
+    public int gameMode = -1;
+    public int timer = -1;
+    public int joinPlayer = -1;
+    public int menuLocation = -1;
+    public int allowTeams = -1;
 
-[SerializeField] ht8b_menu menu;
-[SerializeField] ht8b main;
+    public ht8b_menu menu;
+    public ht8b main;
 
-[SerializeField] bool startGame = false;
+    public bool startGame = false;
 
 #if COMPILE_WITH_TESTS
-public bool forceInteract = false;
+    public bool forceInteract = false;
 #endif
 
-void Interact()
-{
-   if( colourSet != 0 )
-   {
-      menu._in_colourchange_dir = colourSet;
-      menu._on_colourchange();
-   }
+    public override void Interact()
+    {
+        if (colourSet != 0)
+        {
+            menu.colourChangeDir = colourSet;
+            menu.OnColourChange();
+        }
 
-   if( gameMode >= 0 )
-   {
-      menu._in_gamemodeid = gameMode;
-      menu._on_gamemode_change();
-   }
+        if (gameMode >= 0)
+        {
+            menu.inputGameModeID = gameMode;
+            menu.OnGameModeChange();
+        }
 
-   if( timer >= 0 )
-   {
-      menu._in_timelimitid = timer;
-      menu._on_timelimitchange();
-   }
+        if (timer >= 0)
+        {
+            menu.timeLimitID = timer;
+            menu._on_timelimitchange();
+        }
 
-   if( startGame )
-   {
-      // This will disable menu
-      main._tr_newgame();
-   }
+        if (startGame)
+        {
+            // This will disable menu
+            main.StartNewGame();
+        }
 
-   if( allowTeams >= 0 )
-   {
-      menu._in_allow_teams = allowTeams;
-      menu._on_teamallowchange();
-   }
+        if (allowTeams >= 0)
+        {
+            menu.allowTeams = allowTeams;
+            menu.OnTeamAllowChange();
+        }
 
-   if( joinPlayer >= 0 )
-   {
-      menu._in_joinas_id = joinPlayer;
-      menu._on_joinas();
-   }
+        if (joinPlayer >= 0)
+        {
+            menu.joinAsID = joinPlayer;
+            menu._on_joinas();
+        }
 
-   if( menu_loc >= 0 )
-   {
-      menu._in_menu_loc = (uint)menu_loc; 
-      menu._on_menu_change();
-   }
-}
+        if (menuLocation >= 0)
+        {
+            menu.inMenuLocation = (uint)menuLocation;
+            menu.OnMenuChange();
+        }
+    }
 
 #if COMPILE_WITH_TESTS
-void Update()
-{
-   if( forceInteract )
-   {
-      Interact();
-      forceInteract = false;
-   }
-}
+    void Update()
+    {
+        if (forceInteract)
+        {
+            Interact();
+            forceInteract = false;
+        }
+    }
 #endif
 
 }

--- a/us/ht8b_otherhand.cs
+++ b/us/ht8b_otherhand.cs
@@ -4,58 +4,59 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.Udon;
 
-public class ht8b_otherhand : UdonSharpBehaviour {
-
-[SerializeField] GameObject objPrimary;
-ht8b_cue usPrimary;
-
-Vector3 originalDelta;
-bool isHolding = false;
-public bool bOtherHold = false;  // Primary is being held
-Vector3 lockpos;
-
-private void OnPickupUseDown()
+public class ht8b_otherhand : UdonSharpBehaviour
 {
-	usPrimary._otherlock();
-	lockpos = this.transform.position;
-}
 
-private void OnPickupUseUp()	// VR
-{
-	usPrimary._otherunlock();
-}
+    public GameObject objPrimary;
+    private ht8b_cue usPrimary;
 
-private void OnPickup()
-{
-	isHolding = true;
-}
+    private Vector3 originalDelta;
+    private bool isHolding = false;
+    public bool bOtherHold = false;  // Primary is being held
+    private Vector3 lockpos;
 
-private void OnDrop()
-{
-	originalDelta = objPrimary.transform.InverseTransformPoint( this.transform.position );
+    public void Start()
+    {
+        usPrimary = objPrimary.GetComponent<ht8b_cue>();
+        OnDrop();
+    }
 
-	// Clamp within 1 meters in case something got messed up
-	if( originalDelta.sqrMagnitude > 0.6084f )
-	{
-		originalDelta = originalDelta.normalized * 0.78f;
-	}
+    public void Update()
+    {
+        // Pseudo-parented while it left is let go
+        if (!isHolding && bOtherHold)
+        {
+            gameObject.transform.position = objPrimary.transform.TransformPoint(originalDelta);
+        }
+    }
 
-	isHolding = false;
-	usPrimary._otherunlock();
-}
+    public override void OnPickupUseDown()
+    {
+        usPrimary.LockOther();
+        lockpos = gameObject.transform.position;
+    }
 
-private void Update()
-{
-	// Pseudo-parented while it left is let go
-	if( !isHolding && bOtherHold )
-	{
-		this.transform.position = objPrimary.transform.TransformPoint( originalDelta );
-	}
-}
+    public override void OnPickupUseUp()    // VR
+    {
+        usPrimary.UnlockOther();
+    }
 
-private void Start()
-{
-	usPrimary = objPrimary.GetComponent<ht8b_cue>();
-	OnDrop();	
-}
+    public override void OnPickup()
+    {
+        isHolding = true;
+    }
+
+    public override void OnDrop()
+    {
+        originalDelta = objPrimary.transform.InverseTransformPoint(gameObject.transform.position);
+
+        // Clamp within 1 meters in case something got messed up
+        if (originalDelta.sqrMagnitude > 0.6084f)
+        {
+            originalDelta = originalDelta.normalized * 0.78f;
+        }
+
+        isHolding = false;
+        usPrimary.UnlockOther();
+    }
 }

--- a/us/ht8b_positioner.cs
+++ b/us/ht8b_positioner.cs
@@ -4,14 +4,13 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.Udon;
 
-public class ht8b_positioner : UdonSharpBehaviour {
-
-[SerializeField] ht8b main;
-
-// Since v0.3.0: OnPickupUseDown -> OnDrop
-void OnDrop()
+public class ht8b_positioner : UdonSharpBehaviour
 {
-	main._tr_placeball();
-}
+    public ht8b gameStateManager;
 
+    // Since v0.3.0: OnPickupUseDown -> OnDrop
+    public override void OnDrop()
+    {
+        gameStateManager.PlaceBall();
+    }
 }

--- a/us/ht8b_set4b.cs
+++ b/us/ht8b_set4b.cs
@@ -6,19 +6,18 @@ using VRC.Udon;
 
 public class ht8b_set4b : UdonSharpBehaviour
 {
+    public ht8b target;
+    public bool isKorean;
 
-[SerializeField] ht8b target;
-[SerializeField] bool kr;
-
-void Interact()
-{
-	if( kr )
-	{
-		target._tr_sagu();
-	}
-	else
-	{
-		target._tr_yotsudama();
-	}
-}
+    public override void Interact()
+    {
+        if (isKorean)
+        {
+            target.SelectedKoreanFourBall();
+        }
+        else
+        {
+            target.SelectedJapaneseFourBall();
+        }
+    }
 }

--- a/us/ht8b_setHeight.cs
+++ b/us/ht8b_setHeight.cs
@@ -6,10 +6,11 @@ using VRC.Udon;
 
 public class ht8b_setHeight : UdonSharpBehaviour
 {
-    public GameObject HeightCalibrator;
-    public Material _Material;
+    public GameObject heightCalibrator;
+    public Material mat;
+
     void Start()
     {
-        _Material.SetFloat("_ShadowOffset", HeightCalibrator.transform.position.y);
+        mat.SetFloat("_ShadowOffset", heightCalibrator.transform.position.y);
     }
 }


### PR DESCRIPTION
This PR refactors the codebase to read like regular C# rather than C. It follows the following rules:

1. Consts are stored at the top of the class.
2. Vars are stored below Consts.
3. Subscription events (Start, Update...) are stored below Consts.
4. Public methods are stored below Subscriptions.
5. Private methods are stored below Public methods.
6. CONSTS_ARE_DEFINED_WITH_SCREAMING_SNAKE_CASE
7. varsAreDefinedWithSnakeCase
8. MethodsAreDefinedWithPascalCase
9. Best effort is made to avoid Hungarian naming (public Material ballMaterial -> public Material ball)

Some effort has also been made to rip out repetitiveGetComponent calls, properly error and fail if GetComponent returns null, and remove unneeded ifdefs and debug logging.
 
This is a major refactor and is likely to have problematic changes and as such needs thorough testing before it is applied to the codebase.